### PR TITLE
Adds PlainXMLOperationContributor to access to internal XM methods

### DIFF
--- a/plugins/org.eclipse.epsilon.emc.plainxml/src/org/eclipse/epsilon/emc/plainxml/PlainXMLOperationContributor.java
+++ b/plugins/org.eclipse.epsilon.emc.plainxml/src/org/eclipse/epsilon/emc/plainxml/PlainXMLOperationContributor.java
@@ -1,0 +1,197 @@
+package org.eclipse.epsilon.emc.plainxml;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.eclipse.epsilon.eol.dom.Expression;
+import org.eclipse.epsilon.eol.exceptions.EolRuntimeException;
+import org.eclipse.epsilon.eol.execute.context.IEolContext;
+import org.eclipse.epsilon.eol.execute.introspection.java.ObjectMethod;
+import org.eclipse.epsilon.eol.execute.operations.contributors.OperationContributor;
+import org.eclipse.epsilon.eol.util.ReflectionUtil;
+import org.w3c.dom.Element;
+
+public class PlainXMLOperationContributor extends OperationContributor {
+
+	@Override
+	public boolean contributesTo(Object target) {
+		return target instanceof Element;
+	}
+	
+	/**
+	 * We can't find the method if the parameters are unevaluated
+	 */
+	@Override
+	public ObjectMethod findContributedMethodForUnevaluatedParameters(Object target, String name,
+			List<Expression> parameterExpressions, IEolContext context) {
+		return null;
+	}
+	
+	@Override
+	public ObjectMethod findContributedMethodForEvaluatedParameters(
+		Object target,
+		String name,
+		Object[] parameters,
+		IEolContext context,
+		boolean overrideContextOperationContributorRegistry) throws EolRuntimeException {
+		return createObjectMethodFor(target, name, parameters, context, true);
+	}
+	
+	private ObjectMethod createObjectMethodFor(
+		Object target,
+		String name,
+		Object[] parameters,
+		IEolContext context,
+		boolean allowContravariantConversionForParameters) throws EolRuntimeException {	
+		Method method = null;
+		// Maintain a cache of method names if the reflection target is this
+		// so that we don't iterate through all methods every time
+		if (getReflectionTarget(target) == this && cachedMethodNames == null) synchronized (this) {
+			if (cachedMethodNames == null) {
+				cachedMethodNames = ReflectionUtil.getMethodNames(this, includeInheritedMethods());
+			}
+		}
+		
+		if (cachedMethodNames == null || cachedMethodNames.contains(name)) {
+			method = ReflectionUtil.getMethodFor(getReflectionTarget(target),
+		                                   name,
+		                                   parameters,
+		                                   true,
+		                                   allowContravariantConversionForParameters);
+			if (method != null && !method.canAccess(target) ) {
+				// Method is internal, try to find it in the interfaces
+				method = this.searchMethodsFor(
+						this.getMethods(target),
+						name,
+						parameters, allowContravariantConversionForParameters);
+				if (!method.canAccess(target) ) {
+					throw new EolRuntimeException(String.format("The method %s, can not be accessed via reflection in the object %s.", name, target.toString()));
+				}
+			}
+		}
+		
+		if (method != null) {
+			Object reflectionTarget = getReflectionTarget(target);
+			ObjectMethod objectMethod = new ObjectMethod(reflectionTarget, method);
+
+			/*
+			 * If the reflection target is this contributor, then it will need to know about
+			 * the actual operand for the method and the intended context.
+			 */
+			if (reflectionTarget == this) {
+				setTarget(target);
+				setContext(context);
+			}
+			return objectMethod;
+		}
+		else return null;
+	}
+	
+	
+	
+	
+	@Override
+	protected Object getReflectionTarget(Object target) {
+		return target;
+	}
+	
+	
+	/**
+	 * In XML, all implementations have been moved to com.sun.org.apache.xerces.internal, thus,
+	 * the methods found via reflection on the class will be not accessible (Method#canAccess == false).
+	 * As a solution, we find the interfaces implemented by the Class and return the methods on those.
+	 * Since the object's class can extend another class, we also need to search the superclass
+	 * interfaces.
+	 * @param obj
+	 * @return
+	 */
+	private Method[] getMethods(Object obj) {
+		// Closure of all supertypes
+		List<Class<?>> allSupers =superClosure(obj.getClass());
+		List<Class<?>> interfaces = new ArrayList<>(Arrays.asList(obj.getClass().getInterfaces()));
+		interfaces.addAll(allSupers.stream()
+				.map(sc -> Arrays.asList(sc.getInterfaces()))
+				.flatMap(Collection::stream)
+				.collect(Collectors.toList()));		
+		List<Method> result = interfaces.stream()
+				.map(i -> this.getMethods(i))
+				.flatMap(Collection::stream)
+				.collect(Collectors.toList());
+		return result.toArray(new Method[result.size()]);
+	}
+	
+	private List<Class<?>> superClosure(Class<?> type) {
+		Class<?> superclass = type.getSuperclass();
+		List<Class<?>> allSupers = new ArrayList<>();
+		if (superclass == null) {
+			return allSupers;
+		}
+		allSupers.add(superclass);
+		allSupers.addAll(superClosure(type.getSuperclass()));
+		return allSupers;
+	}
+	
+	
+	private List<Method> getMethods(Class<?> intrfce) {
+		return Arrays.asList(intrfce.getMethods());
+	}
+	
+	
+	private Method searchMethodsFor(Method[] methods, String methodName, Object[] parameters, boolean allowContravariantConversionForParameters) {
+		// Antonio: according to the Java Language Specification, Sections 15.12.2.2 to 15.12.2.4,
+		// method resolution is done in three stages: in the first one, no autoboxing is used. In
+		// the second one, autoboxing (like that in our isInstance static method) is used. In the
+		// third one, varargs are used. We should do the same if we want to tell apart remove(Object)
+		// from remove(int) like Java normally would.
+		for (int stage = 0; stage < 2; ++stage) {
+			for (Method method : methods) {
+				if (getMethodName(method).equalsIgnoreCase(methodName)) {
+					Class<?>[] parameterTypes = method.getParameterTypes();
+					boolean isVarargs = method.isVarArgs(),
+							parametersMatch = parameterTypes.length == parameters.length || isVarargs;
+					
+					if (parametersMatch) {
+						//TODO: See why parameter type checking does not work with EolSequence
+						int varargIndex = method.getParameterCount() - 1;
+						int endIndex = isVarargs ? varargIndex : parameterTypes.length;
+						if (parameters.length < endIndex) {
+							continue;
+						}
+						for (int j = 0; j < endIndex && parametersMatch; j++) {
+							Class<?> parameterType = parameterTypes[j];
+							Object parameter = parameters[j];
+							if (allowContravariantConversionForParameters) {
+								parametersMatch = parametersMatch && (stage == 0 ? parameterType.isInstance(parameter) :  ReflectionUtil.isInstance(parameterType, parameter));
+							}
+							else {
+								parametersMatch = parametersMatch && parameterType.equals(parameter.getClass());
+							}
+						}
+						if (isVarargs) {
+							Class<?> varargType = parameterTypes[varargIndex].getComponentType();
+							for (int va = varargIndex; va < parameters.length && parametersMatch; va++) {
+								Object parameter = parameters[va];
+								parametersMatch = (stage == 0 ? varargType.isInstance(parameter) : ReflectionUtil.isInstance(varargType, parameter));
+							}
+						}
+					}
+					if (parametersMatch) {
+						return method;
+					}
+				}
+			}
+		}
+		return null;
+	}
+	
+	private String getMethodName(Method method) {
+		String methodName = method.getName();
+		if (methodName.startsWith("_")) methodName = methodName.substring(1);
+		return methodName;
+	}
+
+}

--- a/plugins/org.eclipse.epsilon.emc.plainxml/src/org/eclipse/epsilon/emc/plainxml/PlainXmlModel.java
+++ b/plugins/org.eclipse.epsilon.emc.plainxml/src/org/eclipse/epsilon/emc/plainxml/PlainXmlModel.java
@@ -35,6 +35,8 @@ import org.eclipse.epsilon.eol.exceptions.models.EolEnumerationValueNotFoundExce
 import org.eclipse.epsilon.eol.exceptions.models.EolModelElementTypeNotFoundException;
 import org.eclipse.epsilon.eol.exceptions.models.EolModelLoadingException;
 import org.eclipse.epsilon.eol.exceptions.models.EolNotInstantiableModelElementTypeException;
+import org.eclipse.epsilon.eol.execute.operations.contributors.IOperationContributorProvider;
+import org.eclipse.epsilon.eol.execute.operations.contributors.OperationContributor;
 import org.eclipse.epsilon.eol.models.CachedModel;
 import org.eclipse.epsilon.eol.models.IRelativePathResolver;
 import org.w3c.dom.Document;
@@ -42,7 +44,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-public class PlainXmlModel extends CachedModel<Element> {
+public class PlainXmlModel extends CachedModel<Element> implements IOperationContributorProvider {
 	
 	protected String idAttributeName = "id";
 	
@@ -53,6 +55,8 @@ public class PlainXmlModel extends CachedModel<Element> {
 	
 	protected ArrayList<Element> createdElements = new ArrayList<>();
 	protected ArrayList<Binding> bindings = new ArrayList<>();
+
+	private OperationContributor operationContributor;
 	protected static final String ELEMENT_TYPE = "Element";
 	protected static final String DEFAULT_NEW_TAG_NAME = "element";
 	public static final String PROPERTY_FILE = "file";
@@ -381,6 +385,7 @@ public class PlainXmlModel extends CachedModel<Element> {
 			else {
 				document = documentBuilder.newDocument();
 			}
+			this.operationContributor = new PlainXMLOperationContributor();
 		}
 		catch (Exception ex) {
 			throw new EolModelLoadingException(ex, this);
@@ -461,4 +466,11 @@ public class PlainXmlModel extends CachedModel<Element> {
 			return store(uri);
 		}
 	}
+
+	@Override
+	public OperationContributor getOperationContributor() {
+		return this.operationContributor;
+	}
+	
+	
 }

--- a/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/execute/operations/contributors/OperationContributor.java
+++ b/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/execute/operations/contributors/OperationContributor.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Set;
 import org.eclipse.epsilon.common.parse.AST;
 import org.eclipse.epsilon.eol.dom.Expression;
+import org.eclipse.epsilon.eol.exceptions.EolRuntimeException;
 import org.eclipse.epsilon.eol.execute.context.IEolContext;
 import org.eclipse.epsilon.eol.execute.introspection.java.ObjectMethod;
 import org.eclipse.epsilon.eol.util.ReflectionUtil;
@@ -39,11 +40,11 @@ public abstract class OperationContributor implements AutoCloseable {
 		return createObjectMethodFor(target, name, new Object[]{new AST()}, context, false);
 	}
 
-	public ObjectMethod findContributedMethodForEvaluatedParameters(Object target, String name, Object[] parameters, IEolContext context) {
+	public ObjectMethod findContributedMethodForEvaluatedParameters(Object target, String name, Object[] parameters, IEolContext context) throws EolRuntimeException {
 		return findContributedMethodForEvaluatedParameters(target, name, parameters, context, true);
 	}
 	
-	public ObjectMethod findContributedMethodForEvaluatedParameters(Object target, String name, Object[] parameters, IEolContext context, boolean overrideContextOperationContributorRegistry) {
+	public ObjectMethod findContributedMethodForEvaluatedParameters(Object target, String name, Object[] parameters, IEolContext context, boolean overrideContextOperationContributorRegistry) throws EolRuntimeException {
 		return createObjectMethodFor(target, name, parameters, context, !overrideContextOperationContributorRegistry);
 	}
 

--- a/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/execute/operations/contributors/OperationContributorRegistry.java
+++ b/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/execute/operations/contributors/OperationContributorRegistry.java
@@ -14,6 +14,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eclipse.epsilon.eol.dom.Expression;
+import org.eclipse.epsilon.eol.exceptions.EolRuntimeException;
 import org.eclipse.epsilon.eol.execute.context.IEolContext;
 import org.eclipse.epsilon.eol.execute.introspection.java.ObjectMethod;
 import org.eclipse.epsilon.eol.execute.operations.contributors.compatibility.StringCompatibilityOperationContributor;
@@ -90,7 +91,12 @@ public class OperationContributorRegistry {
 	 */
 	public ObjectMethod findContributedMethodForEvaluatedParameters(Object target, String name, Object[] parameters, IEolContext context) {
 		for (OperationContributor c : getOperationContributorsFor(target, context)) {
-			ObjectMethod objectMethod = c.findContributedMethodForEvaluatedParameters(target, name, parameters, context, false);
+			ObjectMethod objectMethod = null;
+			try {
+				objectMethod = c.findContributedMethodForEvaluatedParameters(target, name, parameters, context, false);
+			} catch (EolRuntimeException e) {
+				// Can still be found
+			}
 			if (objectMethod != null) {
 				return objectMethod;
 			}

--- a/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/util/ReflectionUtil.java
+++ b/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/util/ReflectionUtil.java
@@ -251,8 +251,8 @@ public class ReflectionUtil {
 
 	public static Object executeMethod(Object obj, Method method, ModuleElement ast, Object... parameters) throws EolRuntimeException {
 		try {
-			if (!method.isAccessible()) {
-				method.setAccessible(true);
+			if (!method.canAccess(obj) ) {
+				throw new EolInternalException(new IllegalAccessException("Method " + method.getName() + " is not accesible."), ast);
 			}
 			return method.invoke(obj, parameters);
 		}

--- a/tests/org.eclipse.epsilon.emc.plainxml.test/src/org/eclipse/epsilon/emc/plainxml/test/PlainXmlModelTests.java
+++ b/tests/org.eclipse.epsilon.emc.plainxml.test/src/org/eclipse/epsilon/emc/plainxml/test/PlainXmlModelTests.java
@@ -53,13 +53,13 @@ public class PlainXmlModelTests {
 	
 	@Test
 	public void testAllOfKind() {
-		assertEquals(evaluator.evaluate("t_library.all.size()"), 1);
-		assertEquals(evaluator.evaluate("t_book.all.size()"), 3);
+		assertEquals(1, evaluator.evaluate("t_library.all.size()"));
+		assertEquals(3, evaluator.evaluate("t_book.all.size()"));
 	}
 	
 	@Test
 	public void testStringAttribute() {
-		assertEquals(evaluator.evaluate("t_book.all.first().a_name"), "b1");
+		assertEquals("b1", evaluator.evaluate("t_book.all.first().a_name"));
 	}
 	
 	@Test
@@ -74,40 +74,54 @@ public class PlainXmlModelTests {
 	
 	@Test
 	public void testIntegerAttribute() {
-		assertEquals(evaluator.evaluate("t_book.all.first().i_pages"), 212);
+		assertEquals(212, evaluator.evaluate("t_book.all.first().i_pages"));
 	}
 	
 	@Test
 	public void testMultipleReferenceAttribute() {
-		assertEquals(evaluator.evaluate("t_book.all.first().x_authors.size()"), 2);				
+		assertEquals(2, evaluator.evaluate("t_book.all.first().x_authors.size()"));				
 	}
 	
 	@Test
 	public void testSingleReferenceAttribute() {
-		assertEquals(evaluator.evaluate("t_book.all.first().x_editor.a_name"), "e1");				
+		assertEquals("e1", evaluator.evaluate("t_book.all.first().x_editor.a_name"));				
 	}
 	
 	@Test 
 	public void testAddRemoveToMultipleReference() {
 		evaluator.execute("t_book.all.first().x_authors.add(t_author.all.third());");
-		assertEquals(evaluator.evaluate("t_book.all.first().x_authors.size()"), 3);				
+		assertEquals(3, evaluator.evaluate("t_book.all.first().x_authors.size()"));				
 		evaluator.execute("t_book.all.first().x_authors.remove(t_author.all.third());");
-		assertEquals(evaluator.evaluate("t_book.all.first().x_authors.size()"), 2);	
+		assertEquals(2, evaluator.evaluate("t_book.all.first().x_authors.size()"));	
 	}
 	
 	@Test
 	public void testSetSingleReference() {
 		evaluator.execute("t_book.all.first().x_editor = t_editor.all.second();");		
-		assertEquals(evaluator.evaluate("t_book.all.first().x_editor.a_name"), "e2");				
+		assertEquals("e2", evaluator.evaluate("t_book.all.first().x_editor.a_name"));				
 		evaluator.execute("t_book.all.first().x_editor = t_editor.all.first();");		
 	}
 	
 	@Test
 	public void testSetMultipleReference() {
 		evaluator.execute("t_book.all.third().x_authors = Sequence{t_author.all.first(), t_author.all.second()};");
-		assertEquals(evaluator.evaluate("t_book.all.third().x_authors.collect(a|a.a_name).concat(',')"), "a1,a2");
+		assertEquals("a1,a2", evaluator.evaluate("t_book.all.third().x_authors.collect(a|a.a_name).concat(',')"));
 		evaluator.execute("t_book.all.third().x_authors = Sequence{};");
-		assertEquals(evaluator.evaluate("t_book.all.third().a_authors"), "");
+		assertEquals("", evaluator.evaluate("t_book.all.third().a_authors"));
+	}
+	
+	@Test
+	public void testAddChildren() {
+		assertEquals(9, evaluator.evaluate("t_library.all().first().children.size()"));
+		evaluator.execute("t_library.all().first().appendChild(new t_book);"); //
+		assertEquals(10, evaluator.evaluate("t_library.all().first().children.size()"));
+	}
+	
+	@Test
+	public void testFindByTagName() {
+		assertEquals(3, evaluator.evaluate("t_library.all().first().children.select(c|c.name=='book').size()"));
+		assertEquals(3, evaluator.evaluate("t_library.all().first().children.select(c|c.tagName=='author').size()"));
+		assertEquals(3, evaluator.evaluate("t_library.all().first().children.select(c|c.tagName=='editor').size()"));
 	}
 	
 }


### PR DESCRIPTION
The issue with tagName access(#5) was a sign of a bigger issue as reported in #6. 

I propose the following fix, which applies specifically to the XML diver, but perhaps can be extended to the JavaPropertyGetter and ReflectionUtil:

1. Find the method as currently done via ReflectionUtil.
1. If the method is accesible, execute it.
1. If not, try to find the method declaration in an implemented interface. This assumes that the interface will be public and not internal. 
1. If the method is accesible, execute it.
1. If still not accesible, throw exception.

Some of the methods in ReflectionUtil that are private where copied into PlainXMLOperationContributor, we could reduce duplication by making them public+static (was not sure about any restrictions).

Adds tests for accessing a method via this way (and for the tagName attribute from #5).
