### PR TITLE
Add add-opens to unit test suite

### DIFF
--- a/tests/org.eclipse.epsilon.test/pom.xml
+++ b/tests/org.eclipse.epsilon.test/pom.xml
@@ -161,7 +161,7 @@
 			</build>
 			<properties>
 				<packaging.type>eclipse-plugin</packaging.type>
-				<argLine>-ea -Xms2g -Xmx6g</argLine>
+				<argLine>-ea -Xms2g -Xmx6g --add-opens=java.base/java.util.stream=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-exports=java.xml/com.sun.org.apache.xerces.internal.dom=ALL-UNNAMED</argLine>
 			</properties>
 		</profile>
 	</profiles>


### PR DESCRIPTION
The `unit` test suite did not have the `add-opens` parameters required to run tests with reflection in modern Java versions.

This pull request adds just that.