### PR TITLE
Picto: try iframe in Markdown inline views when HTML is non-XML

### DIFF
--- a/examples/org.eclipse.epsilon.examples.picto.socialnetwork/socialnetwork/readme.md
+++ b/examples/org.eclipse.epsilon.examples.picto.socialnetwork/socialnetwork/readme.md
@@ -8,7 +8,7 @@ This is a simple way to represent network connections.
 
 ## Embedded "stats" table view
 
-<picto-view path="Stats"/>
+<picto-view path="Stats" autoresize="true"/>
 
 
 ## Embedded PlantUML

--- a/examples/org.eclipse.epsilon.examples.picto.socialnetwork/socialnetwork/readme.md
+++ b/examples/org.eclipse.epsilon.examples.picto.socialnetwork/socialnetwork/readme.md
@@ -6,6 +6,11 @@ This is a simple way to represent network connections.
 
 <picto-view path="Social Network, Alice"/>
 
+## Embedded "stats" table view
+
+<picto-view path="Stats"/>
+
+
 ## Embedded PlantUML
 
 ```render-plantuml

--- a/plugins/org.eclipse.epsilon.picto/src/org/eclipse/epsilon/picto/transformers/elements/MetroHeadAppender.java
+++ b/plugins/org.eclipse.epsilon.picto/src/org/eclipse/epsilon/picto/transformers/elements/MetroHeadAppender.java
@@ -34,6 +34,11 @@ public class MetroHeadAppender extends AppendingElementTransformer {
 		css.setAttribute("href", cdn + "css/metro-all.min.css");
 		root.appendChild(css);
 		
+		// disable min body height (for correct iframe shrinking)
+		Element style = document.createElement("style");
+		style.setTextContent("body {min-height: 1px;}");
+		root.appendChild(style);
+
 		Element js = document.createElement("script");
 		js.setAttribute("defer", "defer");
 		js.setAttribute("src", cdn + "js/metro.min.js");

--- a/plugins/org.eclipse.epsilon.picto/src/org/eclipse/epsilon/picto/transformers/elements/MetroHeadAppender.java
+++ b/plugins/org.eclipse.epsilon.picto/src/org/eclipse/epsilon/picto/transformers/elements/MetroHeadAppender.java
@@ -47,7 +47,7 @@ public class MetroHeadAppender extends AppendingElementTransformer {
 		// for having correct height when shown in an iframe
 		js = document.createElement("script");
 		js.setAttribute("defer", "defer");
-		js.setAttribute("src", "https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.2/iframeResizer.contentWindow.js");
+		js.setAttribute("src", "https://cdn.jsdelivr.net/npm/iframe-resizer@4.2.11/js/iframeResizer.contentWindow.min.js");
 		root.appendChild(js);
 	}
 

--- a/plugins/org.eclipse.epsilon.picto/src/org/eclipse/epsilon/picto/transformers/elements/MetroHeadAppender.java
+++ b/plugins/org.eclipse.epsilon.picto/src/org/eclipse/epsilon/picto/transformers/elements/MetroHeadAppender.java
@@ -38,6 +38,12 @@ public class MetroHeadAppender extends AppendingElementTransformer {
 		js.setAttribute("defer", "defer");
 		js.setAttribute("src", cdn + "js/metro.min.js");
 		root.appendChild(js);
+
+		// for having correct height when shown in an iframe
+		js = document.createElement("script");
+		js.setAttribute("defer", "defer");
+		js.setAttribute("src", "https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.2/iframeResizer.contentWindow.js");
+		root.appendChild(js);
 	}
 
 }

--- a/plugins/org.eclipse.epsilon.picto/src/org/eclipse/epsilon/picto/transformers/elements/ReplacingElementTransformer.java
+++ b/plugins/org.eclipse.epsilon.picto/src/org/eclipse/epsilon/picto/transformers/elements/ReplacingElementTransformer.java
@@ -29,6 +29,10 @@ public abstract class ReplacingElementTransformer extends AbstractHtmlElementTra
 	protected void replace(Element element, ViewContent viewContent, boolean iframe) {
 		Document owner = element.getOwnerDocument();
 
+		if (element.hasAttribute("iframe")) {
+			iframe = true;
+		}
+
 		if (!iframe) {
 			try {
 				Document document = xmlHelper.parse(viewContent.getText());


### PR DESCRIPTION
This PR fixes #14 by wrapping HTML views that are non XML conformant in an iframe.

It also makes use of the [iframe resizer](https://davidjbradshaw.github.io/iframe-resizer/) library to determine proper width and height of the iframe contents at render time.

The use of this library makes necessary to include an inner JS script in those HTML views that are to be referred from a Markdown file, so this must be included in the documentation website. The current PR automatically includes that inner js library to CSV views in `MetroHeadAppender.java`.

The Picto social network example can be checked to see table seamlessly inlined and properly sized in the "Readme" view.