### PR TITLE
ForTask: Return empty array if fileset has no files

### DIFF
--- a/plugins/org.eclipse.epsilon.workflow/ant/org/eclipse/epsilon/workflow/tasks/ForTask.java
+++ b/plugins/org.eclipse.epsilon.workflow/ant/org/eclipse/epsilon/workflow/tasks/ForTask.java
@@ -32,7 +32,7 @@ public class ForTask extends EolTask implements TaskContainer {
 	}
 
 	protected String[] getFiles() {
-		if (fileset == null) return new String[]{};
+		if (fileset == null || fileset.size() == 0) return new String[]{};
 		return fileset.toString().split(";");
 	}
 


### PR DESCRIPTION
Fixes #16

If the fileset has no files then return an empty array.

The getFiles() method relies on the AbstractFileSet toString() method which will return an empty string if there are no included files. We need to check if there are no files, otherwise this will result in a string array with one element (empty string) even though there are no files.