### PR TITLE
EOL: Add collection operation `join` as alias for `concat`

### DIFF
--- a/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/execute/operations/contributors/IterableOperationContributor.java
+++ b/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/execute/operations/contributors/IterableOperationContributor.java
@@ -434,6 +434,25 @@ public class IterableOperationContributor extends OperationContributor {
 		);
 	}
 	
+	/**
+	 * 
+	 * @return
+	 * @since 2.5
+	 */
+	public String join() {
+		return concat("");
+	}
+	
+	/**
+	 * 
+	 * @param delimiter
+	 * @return
+	 * @since 2.5
+	 */
+	public String join(String delimiter) {
+		return concat(delimiter);
+	}
+	
 	public Number max() {
 		return max(0);
 	}


### PR DESCRIPTION
This is for consistency with other languages including Java, JavaScript, C#, Python, Rust, and PHP