### PR TITLE
EGX: Show EGL parse problem details

### DIFF
--- a/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/dom/GenerationRule.java
+++ b/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/dom/GenerationRule.java
@@ -12,6 +12,7 @@ package org.eclipse.epsilon.egl.dom;
 import java.net.URI;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.epsilon.common.module.IModule;
@@ -166,8 +167,11 @@ public class GenerationRule extends ExtensibleNamedRule implements IExecutableMo
 		if (templateCache == null || (eglTemplate = templateCache.get(templateUri)) == null) {
 			eglTemplate = templateFactory.load(templateUri);
 			
-			if (!eglTemplate.getParseProblems().isEmpty()) {
-				throw new EolRuntimeException("Parse error(s) in " + templateUri, templateBlock);
+			List<ParseProblem> problems = eglTemplate.getParseProblems();
+			if (!problems.isEmpty()) {
+				ParseProblem problem = problems.get(0);
+				String reason = "Parse error(s) in " + templateUri + ": " + problem.toString();
+				throw new EolRuntimeException(reason, templateBlock);
 			}
 				
 			if (templateCache != null) {


### PR DESCRIPTION
Currently, when there is a parse error in an EGL file being executed from EGX, there is no info shown about where the error is.
Here is the current error message that is shown:
```
Parse error(s) in file:/C:/Users/username/AppData/Local/Temp/epsilon/rule.egl
	at (C:\Users\username\AppData\Local\Temp\epsilon\transformation.egx@7:0-14:1)
	at (C:\Users\username\AppData\Local\Temp\epsilon\transformation.egx@7:0-14:1)
	at (C:\Users\username\AppData\Local\Temp\epsilon\transformation.egx@1:0-18:1)
```

This PR adds the parse error details to the error message:
```
Parse error(s) in file:/C:/Users/username/AppData/Local/Temp/epsilon/rule.egl: Line: 2, Column: 17, Reason: no viable alternative at input '('
	at (C:\Users\username\AppData\Local\Temp\epsilon\transformation.egx@7:0-14:1)
	at (C:\Users\username\AppData\Local\Temp\epsilon\transformation.egx@7:0-14:1)
	at (C:\Users\username\AppData\Local\Temp\epsilon\transformation.egx@1:0-18:1)
```

It would be nice to be able to format the line and column details in the `(<path>@<line>:<column>-<line>:<column>)` format so that IDEs can hyperlink to the exact location. However, I could not find an easy way to do that. 