### PR TITLE
Improve performance in ECL MatchTrace

### DIFF
--- a/plugins/org.eclipse.epsilon.ecl.engine/src/org/eclipse/epsilon/ecl/dom/MatchRule.java
+++ b/plugins/org.eclipse.epsilon.ecl.engine/src/org/eclipse/epsilon/ecl/dom/MatchRule.java
@@ -1,11 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2008 The University of York.
+ * Copyright (c) 2008-2023 The University of York.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  * 
  * Contributors:
  *     Dimitrios Kolovos - initial API and implementation
+ *     Antonio Garcia-Dominguez - protect against NPE in toString()
  ******************************************************************************/
 package org.eclipse.epsilon.ecl.dom;
 

--- a/plugins/org.eclipse.epsilon.ecl.engine/src/org/eclipse/epsilon/ecl/dom/MatchRule.java
+++ b/plugins/org.eclipse.epsilon.ecl.engine/src/org/eclipse/epsilon/ecl/dom/MatchRule.java
@@ -10,6 +10,7 @@
 package org.eclipse.epsilon.ecl.dom;
 
 import java.util.Collection;
+
 import org.eclipse.epsilon.common.module.IModule;
 import org.eclipse.epsilon.common.parse.AST;
 import org.eclipse.epsilon.common.util.AstUtil;
@@ -232,9 +233,9 @@ public class MatchRule extends ExtensibleNamedRule {
 
 	@Override
 	public String toString() {
-		return getName()+ " (" +
-		leftParameter.getTypeName() + ", " +
-		rightParameter.getTypeName() + ")";
+		return String.format("%s (%s, %s)", getName(),
+			leftParameter == null ? "(no left)" : leftParameter.getTypeName(),
+			rightParameter == null ? "(no right)" : rightParameter.getTypeName());
 	}
 	
 	public boolean isRightDomainDynamic() {

--- a/tests/org.eclipse.epsilon.ecl.engine.test.acceptance/src/org/eclipse/epsilon/ecl/engine/test/acceptance/EclAcceptanceTestSuite.java
+++ b/tests/org.eclipse.epsilon.ecl.engine.test.acceptance/src/org/eclipse/epsilon/ecl/engine/test/acceptance/EclAcceptanceTestSuite.java
@@ -9,10 +9,11 @@
  ******************************************************************************/
 package org.eclipse.epsilon.ecl.engine.test.acceptance;
 
-import org.eclipse.epsilon.ecl.engine.test.acceptance.builtins.*;
+import org.eclipse.epsilon.ecl.engine.test.acceptance.builtins.EclCanAccessBuiltinsTests;
 import org.eclipse.epsilon.ecl.engine.test.acceptance.domain.DomainTests;
-import org.eclipse.epsilon.ecl.engine.test.acceptance.matches.*;
-import org.eclipse.epsilon.ecl.engine.test.acceptance.trees.*;
+import org.eclipse.epsilon.ecl.engine.test.acceptance.matches.MatchesOperationTest;
+import org.eclipse.epsilon.ecl.engine.test.acceptance.trace.MatchTraceTest;
+import org.eclipse.epsilon.ecl.engine.test.acceptance.trees.TestXmlTreeComparison;
 import org.eclipse.epsilon.ecl.engine.test.acceptance.unparser.EclUnparserTests;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
@@ -22,7 +23,7 @@ import org.junit.runners.Suite.SuiteClasses;
 @SuiteClasses({
 	EclCanAccessBuiltinsTests.class, TestXmlTreeComparison.class,
 	MatchesOperationTest.class, DomainTests.class,
-	EclUnparserTests.class
+	EclUnparserTests.class, MatchTraceTest.class
 })
 public class EclAcceptanceTestSuite {
 

--- a/tests/org.eclipse.epsilon.ecl.engine.test.acceptance/src/org/eclipse/epsilon/ecl/engine/test/acceptance/EclAcceptanceTestSuite.java
+++ b/tests/org.eclipse.epsilon.ecl.engine.test.acceptance/src/org/eclipse/epsilon/ecl/engine/test/acceptance/EclAcceptanceTestSuite.java
@@ -1,11 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2011 The University of York.
+ * Copyright (c) 2011-2023 The University of York.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  * 
  * Contributors:
  *     Louis Rose - initial API and implementation
+ *     Antonio Garcia-Dominguez - add MatchTraceTest
  ******************************************************************************/
 package org.eclipse.epsilon.ecl.engine.test.acceptance;
 

--- a/tests/org.eclipse.epsilon.ecl.engine.test.acceptance/src/org/eclipse/epsilon/ecl/engine/test/acceptance/trace/MatchTraceTest.java
+++ b/tests/org.eclipse.epsilon.ecl.engine.test.acceptance/src/org/eclipse/epsilon/ecl/engine/test/acceptance/trace/MatchTraceTest.java
@@ -222,4 +222,20 @@ public class MatchTraceTest {
 		copy.remove(original.iterator().next());
 		assertEquals("Modifying the copy should not impact the original", backup, original);
 	}
+
+	@Test
+	public void multipleMatches() {
+		MatchTrace trace = new MatchTrace();
+
+		String a = "hello", b = "world";
+		MatchRule mr1 = new MatchRule(), mr2 = new MatchRule();
+		Match m1 = new Match(a, b, false, mr1);
+		Match m2 = new Match(a, b, true, mr2);
+		trace.add(m1);
+		trace.add(m2);
+
+		assertSame("Matching order should be preserved", m1, trace.getMatch(a, b));
+		assertEquals("All matches should be available - left side", Arrays.asList(m1, m2),  trace.getMatches(a));
+		assertEquals("All matches should be available - right side", Arrays.asList(m1, m2),  trace.getMatches(b));
+	}
 }

--- a/tests/org.eclipse.epsilon.ecl.engine.test.acceptance/src/org/eclipse/epsilon/ecl/engine/test/acceptance/trace/MatchTraceTest.java
+++ b/tests/org.eclipse.epsilon.ecl.engine.test.acceptance/src/org/eclipse/epsilon/ecl/engine/test/acceptance/trace/MatchTraceTest.java
@@ -1,0 +1,225 @@
+/*******************************************************************************
+ * Copyright (c) 2023 The University of York.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ * 
+ * Contributors:
+ *     Antonio Garcia-Dominguez - initial API and implementation
+ ******************************************************************************/
+package org.eclipse.epsilon.ecl.engine.test.acceptance.trace;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.epsilon.ecl.dom.MatchRule;
+import org.eclipse.epsilon.ecl.trace.Match;
+import org.eclipse.epsilon.ecl.trace.MatchTrace;
+import org.junit.Test;
+
+public class MatchTraceTest {
+
+	@SuppressWarnings("unlikely-arg-type")
+	@Test
+	public void addRemove() {
+		MatchTrace trace = new MatchTrace();
+
+		String left = "hello";
+		String right = "world";
+		MatchRule mr = new MatchRule();
+		Match m = new Match(left, right, true, mr);
+
+		assertTrue("Trace should start empty", trace.isEmpty());
+		assertFalse("Trace should not contain a match that has not been added", trace.contains(m));
+		assertFalse("Trace should not contain something that is not a Match", trace.contains("not a match"));
+
+		trace.add(m);
+		assertTrue("Trace should contain the match that was just added", trace.contains(m));
+		assertFalse("Trace should not be considered empty after an add", trace.isEmpty());
+		trace.remove(m);
+		assertTrue("Trace should be considered empty after removing its only element", trace.isEmpty());
+	}
+
+	@Test
+	public void addRemoveViaIterator() {
+		MatchTrace trace = new MatchTrace();
+
+		String left = "hello";
+		String right = "world";
+		MatchRule mr = new MatchRule();
+		Match m = new Match(left, right, true, mr);
+		trace.add(m);
+
+		Iterator<Match> itMatches = trace.iterator();
+		assertSame("Iterator should return the only element", m, itMatches.next());
+
+		itMatches.remove();
+		assertTrue("Trace should be considered empty after removing its only element", trace.isEmpty());
+
+		assertFalse(itMatches.hasNext());
+	}
+
+	@Test
+	public void addClear() {
+		MatchTrace trace = new MatchTrace();
+
+		trace.add("hello", "world", true, new MatchRule());
+		assertFalse("After an add, the trace should not be empty", trace.isEmpty());
+		trace.clear();
+		assertTrue("After a clear, the trace should be empty", trace.isEmpty());
+	}
+
+	@SuppressWarnings("unlikely-arg-type")
+	@Test
+	public void removeNonMatch() {
+		MatchTrace trace = new MatchTrace();
+
+		// Shouldn't raise an error
+		trace.remove("not a match");
+	}
+
+	@Test(expected=IllegalStateException.class)
+	public void removeWithoutNext() {
+		MatchTrace trace = new MatchTrace();
+		trace.iterator().remove();
+	}
+
+	@Test(expected=NoSuchElementException.class)
+	public void nextBeyondEnd() {
+		MatchTrace trace = new MatchTrace();
+		trace.iterator().next();
+	}
+
+	@Test
+	public void streamLeft() {
+		MatchTrace trace = new MatchTrace();
+
+		MatchRule mr = new MatchRule();
+		trace.add(1, 3, false, mr);
+		trace.add(2, 4, true, mr);
+
+		Set<Object> lefts = trace.stream().map(m -> m.getLeft()).collect(Collectors.toSet());
+		assertEquals(new HashSet<>(Arrays.asList(1, 2)), lefts);
+	}
+
+	@Test
+	public void parallelStreamRight() {
+		MatchTrace trace = new MatchTrace();
+
+		MatchRule mr = new MatchRule();
+		trace.add(1, 3, false, mr);
+		trace.add(2, 4, true, mr);
+
+		Set<Object> rights = trace.parallelStream().map(m -> m.getRight()).collect(Collectors.toSet());
+		assertEquals(new HashSet<>(Arrays.asList(3, 4)), rights);
+	}
+
+	@Test
+	public void getMatches() {
+		MatchTrace trace = new MatchTrace();
+
+		String a = "hello", b = "happy", c = "world", d = "nothing";
+		MatchRule mr1 = new MatchRule(), mr2 = new MatchRule();
+
+		assertNull("No matches should be returned on an empty trace", trace.getMatch(c));
+
+		trace.add(a, b, false, mr1);
+		trace.add(a, c, true, mr1);
+		trace.add(b, c, true, mr2);
+		trace.add(b, d, false, mr2);
+
+		assertEquals(new HashSet<>(Arrays.asList(b, c)),
+			trace.getMatches(a).stream().map(m -> m.getRight()).collect(Collectors.toSet()));
+
+		assertEquals(new HashSet<>(Arrays.asList(a, b)),
+				trace.getMatches(c).stream().map(m -> m.getLeft()).collect(Collectors.toSet()));
+
+		assertSame(c, trace.getMatch(b).getRight());
+		assertNotNull(trace.getMatch(c));
+		assertNull(trace.getMatch(d));
+
+		assertSame(c, trace.getMatch(a, mr1).getRight());
+		assertNull(trace.getMatch(a, mr2));
+		assertNull(trace.getMatch("nonexistent", mr1));
+
+		assertTrue(trace.hasBeenMatched(a));
+		assertTrue(trace.hasBeenMatched(c));
+		assertFalse(trace.hasBeenMatched("nonexistent"));
+	}
+
+	@Test
+	public void batchOperations() {
+		MatchTrace trace = new MatchTrace();
+
+		String a = "hello", b = "happy", c = "world", d = "nothing";
+		MatchRule mr1 = new MatchRule(), mr2 = new MatchRule();
+
+		Match m1 = new Match(a, b, false, mr1);
+		Match m2 = new Match(a, c, true, mr1);
+		Match m3 = new Match(b, c, true, mr2);
+		Match m4 = new Match(b, d, false, mr2);
+
+		trace.addAll(Arrays.asList(m1, m2, m3));
+
+		assertTrue(trace.containsAll(Arrays.asList(m2, m3)));
+		assertFalse(trace.containsAll(Arrays.asList(m3, m4)));
+
+		assertTrue(trace.removeAll(Arrays.asList(m3, m4)));
+		assertFalse(trace.removeAll(Arrays.asList(m3, m4)));
+		assertTrue(trace.contains(m1));
+	}
+
+	@Test
+	public void retainAll() {
+		MatchTrace trace = new MatchTrace();
+
+		String a = "hello", b = "happy", c = "world", d = "nothing";
+		MatchRule mr1 = new MatchRule(), mr2 = new MatchRule();
+
+		Match m1 = new Match(a, b, false, mr1);
+		Match m2 = new Match(a, c, true, mr1);
+		Match m3 = new Match(b, c, true, mr2);
+		Match m4 = new Match(b, d, false, mr2);
+
+		trace.addAll(Arrays.asList(m1, m2, m3));
+
+		assertTrue(trace.retainAll(Arrays.asList(m2, m3, m4)));
+		assertFalse(trace.contains(m1));
+		assertTrue(trace.contains(m2));
+		assertTrue(trace.contains(m3));
+		assertFalse(trace.contains(m4));
+	}
+
+	@Test
+	public void copyConstructor() {
+		MatchTrace original = new MatchTrace();
+
+		String a = "hello", b = "happy", c = "world", d = "nothing";
+		MatchRule mr1 = new MatchRule(), mr2 = new MatchRule();
+		original.add(a, b, false, mr1);
+		original.add(a, c, true, mr1);
+		original.add(b, c, true, mr2);
+		original.add(b, d, false, mr2);
+
+		MatchTrace copy = new MatchTrace(original);
+
+		assertEquals("The copy should be equal to the original", original, copy);
+		assertEquals("The copy should be have equal hashCode to the original", original.hashCode(), copy.hashCode());
+
+		MatchTrace backup = new MatchTrace(original);
+
+		copy.remove(original.iterator().next());
+		assertEquals("Modifying the copy should not impact the original", backup, original);
+	}
+}


### PR DESCRIPTION
# Summary

This PR reimplements `MatchTrace` so it is based on lookup rather than storing flat lists of matches. The data structure assumes that each (left, right) pair can only have one associated `Match`: this seems to be the assumption from looking at the `getMatch(Object left, Object right)` method.

# Details

It uses two 2-level `IdentityHashMap`s (left -> right -> Match, and right -> left -> Match). This allows it to quickly find matches for an object whether it participated on the left or right side, while also efficiently looping through all Match objects by only traversing the left -> right -> Match map. I have reimplemented the `iterator()` and `stream()` methods with new iterator and spliterator implementations, which are based on iterators and spliterators over the underlying maps.

This PR adds a `MatchTraceTest` suite specifically for this data structure, which attempts to cover as much as possible from the data structure: the ECL acceptance tests only covered a small part of the `MatchTrace` methods. It was passing all regular tests in my Eclipse instance, but we should wait to see what Jenkins thinks :-).

# Performance

In terms of performance, I have noticed a significant improvement in the TTC 2023 Containers to MiniYAML example if you stop using guards and only use straight comparisons.

## Guard-based ECL script

In the current version of the reference implementation of this case, I had to use `guard`s instead of `compare` expressions (leaving them to `true`) as otherwise the execution would take too long.

With the list-based MatchRule and `guard` expressions, limiting the generated models to 50 containers, I get an execution time of 8.931s in the incremental forward case (which uses ECL+EML for merging):

```
------------------
Incr. FWD:
------------------
n_containers,n_volumes,n_images,Epsilon
50,3,4,8.931
```

With the map-based MatchRule and `guard` expressions, there is not much change:

```
------------------
Incr. FWD:
------------------
n_containers,n_volumes,n_images,Epsilon
50,3,4,8.921
```

I checked with VisualVM and the execution time for those two configurations is dominated by finding the appropriate method to invoke via reflection, by the way:

![image](https://github.com/eclipse/epsilon/assets/46504/9d1b2333-6b79-43d5-bcdf-f67ac0566e6b)

## Guard-less ECL script

As said above, the list-based MatchRule cannot work with only `compare` expressions: I've been waiting for over 5 minutes for it to finish.

However, with the map-based MatchRule and only using `compare` expressions (without guards), execution times actually drop below those of the guard-based ECL script (to 3.86s):

```
------------------
Incr. FWD:
------------------
n_containers,n_volumes,n_images,Epsilon
50,3,4,3.866
```

It looks like this scales much better when you have a significant number of (left, right) pairs to deal with. At the same time, I wonder what may be happening with the guards, as using them can actually slow down an ECL script. That's for another PR, I guess.