### PR TITLE
TransformationTrace: use map->map->list data structure instead of flat list

### DIFF
--- a/plugins/org.eclipse.epsilon.etl.engine/src/org/eclipse/epsilon/etl/dom/TransformationRule.java
+++ b/plugins/org.eclipse.epsilon.etl.engine/src/org/eclipse/epsilon/etl/dom/TransformationRule.java
@@ -193,7 +193,7 @@ public class TransformationRule extends ExtensibleNamedRule {
 	
 	public Collection<?> transform(Object source, IEtlContext context) throws EolRuntimeException {
 		if (hasTransformed(source)) {
-			return context.getTransformationTrace().getTransformationTargets(source, getName());
+			return context.getTransformationTrace().getTransformationTargets(source, this);
 		}
 		else {
 			transformedElements.add(source);

--- a/plugins/org.eclipse.epsilon.etl.engine/src/org/eclipse/epsilon/etl/trace/TransformationTrace.java
+++ b/plugins/org.eclipse.epsilon.etl.engine/src/org/eclipse/epsilon/etl/trace/TransformationTrace.java
@@ -1,24 +1,203 @@
 /*******************************************************************************
- * Copyright (c) 2008 The University of York.
+ * Copyright (c) 2008-2023 The University of York.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  * 
  * Contributors:
  *     Dimitrios Kolovos - initial API and implementation
+ *     Antonio Garcia-Dominguez - use map->map->list data structure
+ *                                and computed collection views
  ******************************************************************************/
 package org.eclipse.epsilon.etl.trace;
 
-import java.util.*;
-import org.eclipse.epsilon.common.concurrent.ConcurrencyUtils;
-import org.eclipse.epsilon.common.util.CollectionUtil;
+import java.util.AbstractCollection;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.NoSuchElementException;
+
 import org.eclipse.epsilon.etl.dom.TransformationRule;
 
 public class TransformationTrace {
 	
-	Map<Object, Collection<Transformation>> cache;
-	Collection<Transformation> transformations;
-	boolean isConcurrent;
+	/**
+	 * Unmodifiable view of the targets for a given transformation.
+	 */
+	private class TransformationTargetsCollection extends AbstractCollection<Object> {
+		private final List<Transformation> txList;
+
+		public TransformationTargetsCollection(List<Transformation> txList) {
+			this.txList = txList;
+		}
+
+		@Override
+		public Iterator<Object> iterator() {
+			return new Iterator<Object>() {
+				Iterator<Transformation> itTransformation = txList.iterator();
+				Iterator<Object> itTarget;
+				Object next;
+
+				@Override
+				public boolean hasNext() {
+					if (next == null) {
+						while (itTarget == null || !itTarget.hasNext()) {
+							if (itTransformation.hasNext()) {
+								itTarget = itTransformation.next().getTargets().iterator();
+							} else {
+								return false;
+							}
+						}
+						next = itTarget.next();
+					}
+					return next != null;
+				}
+
+				@Override
+				public Object next() {
+					if (!hasNext()) throw new NoSuchElementException();
+					Object ret = next;
+					next = null;
+					return ret;
+				}
+			};
+		}
+
+		@Override
+		public int size() {
+			return txList.size();
+		}
+	}
+
+	/**
+	 * Unmodifiable view of the transformations from a given source.
+	 */
+	private class SourceTransformationsCollection extends AbstractCollection<Transformation> {
+		private final Object source;
+
+		public SourceTransformationsCollection(Object source) {
+			this.source = source;
+		}
+
+		@Override
+		public Iterator<Transformation> iterator() {
+			Map<TransformationRule, List<Transformation>> ruleMap = transformations.get(source);
+			if (ruleMap == null) {
+				return Collections.emptyIterator();
+			}
+
+			return new Iterator<Transformation>() {
+				Iterator<List<Transformation>> itList = ruleMap.values().iterator();
+				Iterator<Transformation> itTransformation;
+				Transformation next;
+
+				@Override
+				public boolean hasNext() {
+					if (next == null) {
+						while (itTransformation == null || !itTransformation.hasNext()) {
+							if (itList.hasNext()) {
+								itTransformation = itList.next().iterator();
+							} else {
+								return false;
+							}
+						}
+
+						next = itTransformation.next();
+					}
+					return next != null;
+				}
+
+				@Override
+				public Transformation next() {
+					if (!hasNext()) throw new NoSuchElementException();
+
+					Transformation ret = next;
+					next = null;
+					return ret;
+				}
+			};
+		}
+
+		@Override
+		public int size() {
+			Map<TransformationRule, List<Transformation>> ruleMap = transformations.get(source);
+			if (ruleMap == null) {
+				return 0;
+			}
+
+			int size = 0;
+			for (List<Transformation> l : ruleMap.values()) {
+				size += l.size();
+			}
+			return size;
+		}
+	}
+
+	/**
+	 * Unmodifiable flat view of all the transformations in this trace.
+	 */
+	private class TransformationsCollection extends AbstractCollection<Transformation> {
+		@Override
+		public Iterator<Transformation> iterator() {
+			return new Iterator<Transformation>() {
+				Iterator<Map<TransformationRule, List<Transformation>>> itObjects = transformations.values().iterator();
+				Iterator<List<Transformation>> itTransformationLists;
+				Iterator<Transformation> itTransformation;
+				Transformation next;
+
+				@Override
+				public boolean hasNext() {
+					if (next == null) {
+						while (itTransformation == null || !itTransformation.hasNext()) {
+							while (itTransformationLists == null || !itTransformationLists.hasNext()) {
+								if (itObjects.hasNext()) {
+									itTransformationLists = itObjects.next().values().iterator();
+								} else {
+									// No more objects left - we're done
+									itTransformationLists = null;
+									itTransformation = null;
+									return false;
+								}
+							}
+
+							itTransformation = itTransformationLists.next().iterator();
+						}
+
+						next = itTransformation.next();
+					}
+
+					return next != null;
+				}
+
+				@Override
+				public Transformation next() {
+					if (!hasNext()) throw new NoSuchElementException();
+					Transformation ret = next;
+					next = null;
+					return ret;
+				}
+			};
+		}
+
+		@Override
+		public int size() {
+			int size = 0;
+			for (Map<TransformationRule, List<Transformation>> objectMap : transformations.values()) {
+				for (List<Transformation> txList : objectMap.values()) {
+					size += txList.size();
+				}
+			}
+			return size;
+		}
+	}
+
+	final Map<Object, Map<TransformationRule, List<Transformation>>> transformations;
+	final boolean isConcurrent;
 	
 	public TransformationTrace() {
 		this(false);
@@ -26,47 +205,65 @@ public class TransformationTrace {
 	
 	public TransformationTrace(boolean concurrent) {
 		this.isConcurrent = concurrent;
-		cache = concurrent ? ConcurrencyUtils.concurrentMap() : new HashMap<>();
-		transformations = newCollection();
+		transformations = createIdentityMap();
 	}
-	
-	<T> Collection<T> newCollection() {
-		return isConcurrent ? new Vector<>() : new ArrayList<>();
+
+	private <K, V> Map<K, V> createIdentityMap() {
+		return isConcurrent ? Collections.synchronizedMap(new LinkedHashMap<>()) : new LinkedHashMap<>();
 	}
-	
+
+	private void syncOn(Object syncTarget, Runnable r) {
+		if (isConcurrent) {
+			synchronized (syncTarget) {
+				r.run();
+			}
+		} else {
+			r.run();
+		}
+	}
+
 	public void add(Object source, Collection<Object> targets, TransformationRule rule) {
 		Transformation transformation = new Transformation(source, targets);
 		transformation.setRule(rule);
-		transformations.add(transformation);
-		Collection<Transformation> transformations = cache.get(source);
-		if (transformations == null) {
-			cache.put(source, transformations = newCollection());
-		}
-		transformations.add(transformation);
+
+		List<Transformation> sourceRuleTransformations = transformations
+			.computeIfAbsent(source, (k) -> createIdentityMap())
+			.computeIfAbsent(rule, (k) -> new ArrayList<>());
+
+		syncOn(sourceRuleTransformations, () -> sourceRuleTransformations.add(transformation));
 	}
 	
 	public Collection<Transformation> getTransformations() {
-		return transformations;
+		return new TransformationsCollection();
 	}
 	
-	public  Collection<Transformation> getTransformations(Object source) {
-		Collection<Transformation> t =  cache.get(source);
-		return t != null ? t : newCollection();
+	public Collection<Transformation> getTransformations(Object source) {
+		return new SourceTransformationsCollection(source);
 	}
 
-	public Collection<?> getTransformationTargets(Object source, String rule) {
-		Collection<Object> targets = CollectionUtil.createDefaultList();
-		for (Transformation transformation : getTransformations()) {
-			if (rule == null || rule.equals(transformation.getRule().getName())) {
-				if (source.equals(transformation.source)) {					
-					targets.addAll(transformation.getTargets());
-				}
-			}
+	/**
+	 * Returns an unmodifiable view of the transformation targets for a given source and rule name.
+	 */
+	public Collection<?> getTransformationTargets(Object source, TransformationRule rule) {
+		Map<TransformationRule, List<Transformation>> sourceMap = transformations.get(source);
+		if (sourceMap == null) {
+			return Collections.emptyList();
 		}
-		return targets;
+
+		List<Transformation> txList = sourceMap.get(rule);
+		if (txList == null) {
+			return Collections.emptyList();
+		}
+
+		return new TransformationTargetsCollection(txList);
 	}
-	
+
 	public boolean containsTransformedBy(TransformationRule rule) {
-		return getTransformations().stream().anyMatch(t -> t.getRule() == rule);
+		for (Entry<Object, Map<TransformationRule, List<Transformation>>> entry : transformations.entrySet()) {
+			if (entry.getValue().containsKey(rule)) {
+				return true;
+			}
+		};
+		return false;
 	}
 }

--- a/tests/org.eclipse.epsilon.test.dependencies/src/org/eclipse/epsilon/test/util/ResourceComparator.java
+++ b/tests/org.eclipse.epsilon.test.dependencies/src/org/eclipse/epsilon/test/util/ResourceComparator.java
@@ -74,6 +74,11 @@ public class ResourceComparator {
 				if (ref.isMany()) {
 					EList<?> cv1 = (EList<?>) o1.eGet(ref);
 					EList<?> cv2 = (EList<?>) o2.eGet(ref);
+
+					assertEquals(
+						String.format("The number of elements for many-valued reference %s of objects %s and %s should match",
+								ref.getName(), EcoreUtil.getURI(o1), EcoreUtil.getURI(o2)),
+						cv1.size(), cv2.size());
 					
 					int j = 0;
 					for (Object v1 : cv1) {


### PR DESCRIPTION
This PR changes TransformationTrace so it uses a map-map-list data structure (source -> rule -> transformations) instead of a flat list of `Transformation`s. It uses `LinkedHashMap`s to preserve order (needed to pass the OO2DB test).

Performance improved for the largest of the four KMEHR to FHIR models, going from 188.56s to 82.68s:

![image](https://github.com/eclipse/epsilon/assets/46504/6efb3c87-b0c4-44f8-a571-46de11ffa854)

One detail is that I changed the signature of the `getTransformationTargets` method a bit, from this:

```
public Collection<?> getTransformationTargets(Object source, String ruleName)
```

To this:

```
public Collection<?> getTransformationTargets(Object source, TransformationRule rule)
```

It only seemed to be used from a single place in our codebase, and we are [passing all tests](https://ci.eclipse.org/epsilon/job/interim-kubernetes/job/43-gettransformationtargets-in-transformationtrace-needs-optimising/1/) in Jenkins. I have also run the normal and plugged-in tests from Eclipse.