### PR TITLE
ECL: use a Guava Network for MatchTrace

### DIFF
--- a/plugins/org.eclipse.epsilon.ecl.engine/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.epsilon.ecl.engine/META-INF/MANIFEST.MF
@@ -5,7 +5,8 @@ Bundle-SymbolicName: org.eclipse.epsilon.ecl.engine
 Bundle-Version: 2.5.0.qualifier
 Bundle-Vendor: Eclipse Modeling Project
 Require-Bundle: org.eclipse.epsilon.eol.engine,
- org.eclipse.epsilon.erl.engine;visibility:=reexport
+ org.eclipse.epsilon.erl.engine;visibility:=reexport,
+ com.google.guava;bundle-version="27.1.0"
 Export-Package: org.eclipse.epsilon.ecl,
  org.eclipse.epsilon.ecl.concurrent,
  org.eclipse.epsilon.ecl.dom,

--- a/plugins/org.eclipse.epsilon.ecl.engine/pom-plain.xml
+++ b/plugins/org.eclipse.epsilon.ecl.engine/pom-plain.xml
@@ -25,6 +25,10 @@
       <artifactId>org.eclipse.epsilon.erl.engine</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/plugins/org.eclipse.epsilon.ecl.engine/src/org/eclipse/epsilon/ecl/trace/Match.java
+++ b/plugins/org.eclipse.epsilon.ecl.engine/src/org/eclipse/epsilon/ecl/trace/Match.java
@@ -10,11 +10,12 @@
 package org.eclipse.epsilon.ecl.trace;
 
 import java.util.Objects;
+
 import org.eclipse.epsilon.ecl.dom.MatchRule;
 import org.eclipse.epsilon.eol.types.EolMap;
 
 public class Match {
-	
+
 	/**
 	 * The left object of the match
 	 */

--- a/tests/org.eclipse.epsilon.ecl.engine.test.acceptance/src/org/eclipse/epsilon/ecl/engine/test/acceptance/trace/MatchTraceTest.java
+++ b/tests/org.eclipse.epsilon.ecl.engine.test.acceptance/src/org/eclipse/epsilon/ecl/engine/test/acceptance/trace/MatchTraceTest.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
@@ -64,10 +65,8 @@ public class MatchTraceTest {
 		Iterator<Match> itMatches = trace.iterator();
 		assertSame("Iterator should return the only element", m, itMatches.next());
 
-		itMatches.remove();
-		assertTrue("Trace should be considered empty after removing its only element", trace.isEmpty());
-
-		assertFalse(itMatches.hasNext());
+		// Guava iterators over views do not support modification
+		assertThrows(UnsupportedOperationException.class, () -> itMatches.remove());
 	}
 
 	@Test
@@ -87,12 +86,6 @@ public class MatchTraceTest {
 
 		// Shouldn't raise an error
 		trace.remove("not a match");
-	}
-
-	@Test(expected=IllegalStateException.class)
-	public void removeWithoutNext() {
-		MatchTrace trace = new MatchTrace();
-		trace.iterator().remove();
 	}
 
 	@Test(expected=NoSuchElementException.class)
@@ -129,7 +122,7 @@ public class MatchTraceTest {
 	public void getMatches() {
 		MatchTrace trace = new MatchTrace();
 
-		String a = "hello", b = "happy", c = "world", d = "nothing";
+		String a = "a", b = "b", c = "c", d = "d";
 		MatchRule mr1 = new MatchRule(), mr2 = new MatchRule();
 
 		assertNull("No matches should be returned on an empty trace", trace.getMatch(c));
@@ -235,7 +228,7 @@ public class MatchTraceTest {
 		trace.add(m2);
 
 		assertSame("Matching order should be preserved", m1, trace.getMatch(a, b));
-		assertEquals("All matches should be available - left side", Arrays.asList(m1, m2),  trace.getMatches(a));
-		assertEquals("All matches should be available - right side", Arrays.asList(m1, m2),  trace.getMatches(b));
+		assertEquals("All matches should be available - left side", new HashSet<>(Arrays.asList(m1, m2)), new HashSet<>(trace.getMatches(a)));
+		assertEquals("All matches should be available - right side", new HashSet<>(Arrays.asList(m1, m2)), new HashSet<>(trace.getMatches(b)));
 	}
 }


### PR DESCRIPTION
This pull request replaces the recent optimisation of the `MatchTrace` in ECL with a Guava `Network` (a directed multigraph, configured to allows parallel edges between the same pair of nodes and self-loops).

In this graph, a match from a to b is represented as an edge from a to b, and is associated with its `Match` object.

This pull request shortens `MatchTrace` by about 174 lines, and in my opinion leaves it in a more readable state. There are some caveats, though:

* Guava `MutableNetwork`s do not offer any thread-safety guarantees, so we have to manually synchronise on them when `concurrent = true`. I've implemented a `syncOn` function that does that.
* While the total set of edges is ordered by insertion in the `Network`, the various views coming from it (e.g. in/out edges of a given object) are not. I had to implement a map that keeps track of insertion order for matches myself. This is a [known issue in Guava `Network`s](https://github.com/google/guava/issues/2650).
* The various views of a Guava Network (e.g. the `.edges()` and `.nodes()`) views cannot be modified, so the `iterator()` produced by `MatchTrace` does not support modification anymore.

The good news is that this seems to have pretty much kept (or perhaps slightly improved) the performance of the IncrFWD scenario in the reference implementation of the TTC 2023 Containers to MiniYAML case, compared to the [one from the Map-based structure](https://github.com/eclipse/epsilon/pull/40#issuecomment-1614668560):

```
------------------
Incr. FWD:
------------------
n_containers,n_volumes,n_images,Epsilon
50,3,4,4.977
```