### PR TITLE
Add edge internal browser option to picto preferences

### DIFF
--- a/plugins/org.eclipse.epsilon.picto/src/org/eclipse/epsilon/picto/PictoView.java
+++ b/plugins/org.eclipse.epsilon.picto/src/org/eclipse/epsilon/picto/PictoView.java
@@ -22,6 +22,7 @@ import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.epsilon.common.dt.EpsilonCommonsPlugin;
 import org.eclipse.epsilon.common.dt.console.EpsilonConsole;
 import org.eclipse.epsilon.common.dt.util.LogUtil;
+import org.eclipse.epsilon.common.util.OperatingSystem;
 import org.eclipse.epsilon.picto.ViewRenderer.ZoomType;
 import org.eclipse.epsilon.picto.actions.BackAction;
 import org.eclipse.epsilon.picto.actions.CopyToClipboardAction;
@@ -164,7 +165,7 @@ public class PictoView extends ViewPart {
 		treeViewer.addDoubleClickListener(event -> filteredTree.clearFilterText());
 		
 		browserContainer = new BrowserContainer(sashForm, SWT.NONE);
-		viewRenderer = new ViewRenderer(new Browser(browserContainer, SWT.NONE));
+		viewRenderer = new ViewRenderer(createBrowser(browserContainer));
 		
 		Browser browser = viewRenderer.getBrowser();
 		for (PictoBrowserFunction pbf : browserFunctions) {
@@ -262,6 +263,17 @@ public class PictoView extends ViewPart {
 		
 		this.getSite().getPage().addPartListener(partListener);
 
+	}
+
+	protected Browser createBrowser(BrowserContainer container) {
+		int browserStyle = SWT.NONE;
+
+		if (OperatingSystem.isWindows() &&
+				EpsilonCommonsPlugin.getDefault().getPreferenceStore().getBoolean(PictoPreferencePage.INTERNAL_BROWSER_EDGE)) {
+			browserStyle = SWT.EDGE;
+		}
+
+		return new Browser(browserContainer, browserStyle);
 	}
 
 	public void render(IEditorPart editor) {

--- a/plugins/org.eclipse.epsilon.picto/src/org/eclipse/epsilon/picto/preferences/PictoPreferencePage.java
+++ b/plugins/org.eclipse.epsilon.picto/src/org/eclipse/epsilon/picto/preferences/PictoPreferencePage.java
@@ -39,17 +39,22 @@ public class PictoPreferencePage extends PreferencePage implements IWorkbenchPre
 	public static final String KROKI_URL = "kroki.url";
 	public static final String DEFAULT_KROKI_URL = "https://kroki.io";
 	
+	public static final String INTERNAL_BROWSER_EDGE = "internalbrowser.edge";
+	public static final boolean DEFAULT_INTERNAL_BROWSER_EDGE = false;
+
 	protected final ArrayList<FieldEditor> fieldEditors = new ArrayList<>();
 	protected final IPreferenceStore preferences = EpsilonCommonsPlugin.getDefault().getPreferenceStore();
 
 	private IntegerFieldEditor timeoutEditor;
 	private BooleanFieldEditor verbatimBooleanEditor;
 	private StringFieldEditor krokiURLEditor;
+	private BooleanFieldEditor internalBrowserEdgeEditor;
 	
 	public PictoPreferencePage() {
 		preferences.setDefault(PROPERTY_RENDER_VERBATIM, DEFAULT_RENDER_VERBATIM);
 		preferences.setDefault(TIMEOUT, DEFAULT_TIMEOUT);
 		preferences.setDefault(KROKI_URL, DEFAULT_KROKI_URL);
+		preferences.setDefault(INTERNAL_BROWSER_EDGE, DEFAULT_INTERNAL_BROWSER_EDGE);
 	}
 
 	@Override
@@ -65,10 +70,19 @@ public class PictoPreferencePage extends PreferencePage implements IWorkbenchPre
 		final Label lblSeparator = new Label(composite, SWT.SEPARATOR | SWT.HORIZONTAL);
 		lblSeparator.setLayoutData(new GridData(SWT.FILL, SWT.TOP, true, false, 2, 1));
 		krokiURLEditor = new StringFieldEditor(KROKI_URL, "Kroki server base URL", composite);
+		
+		final Label lblSeparator2 = new Label(composite, SWT.SEPARATOR | SWT.HORIZONTAL);
+		lblSeparator2.setLayoutData(new GridData(SWT.FILL, SWT.TOP, true, false, 2, 1));
+
+		internalBrowserEdgeEditor = new BooleanFieldEditor(INTERNAL_BROWSER_EDGE,
+				"In Windows, use Edge as the internal browser (requires reloading the Picto view(s))", composite);
+		// Fills in the second column in the field editor
+		new Label(parent, SWT.NONE);
 
 		fieldEditors.add(verbatimBooleanEditor);
 		fieldEditors.add(timeoutEditor);
 		fieldEditors.add(krokiURLEditor);
+		fieldEditors.add(internalBrowserEdgeEditor);
 
 		for (FieldEditor fieldEditor : fieldEditors) {
 			fieldEditor.setPreferenceStore(preferences);
@@ -98,6 +112,7 @@ public class PictoPreferencePage extends PreferencePage implements IWorkbenchPre
 		timeoutEditor.loadDefault();
 		verbatimBooleanEditor.loadDefault();
 		krokiURLEditor.loadDefault();
+		internalBrowserEdgeEditor.loadDefault();
 
 		super.performDefaults();
 	}

--- a/plugins/org.eclipse.epsilon.picto/src/org/eclipse/epsilon/picto/preferences/PictoPreferencePage.java
+++ b/plugins/org.eclipse.epsilon.picto/src/org/eclipse/epsilon/picto/preferences/PictoPreferencePage.java
@@ -75,7 +75,7 @@ public class PictoPreferencePage extends PreferencePage implements IWorkbenchPre
 		lblSeparator2.setLayoutData(new GridData(SWT.FILL, SWT.TOP, true, false, 2, 1));
 
 		internalBrowserEdgeEditor = new BooleanFieldEditor(INTERNAL_BROWSER_EDGE,
-				"In Windows, use Edge as the internal browser (requires reloading the Picto view(s))", composite);
+				"Use Edge as the embedded browser (requires reloading open Picto views, Windows only)", composite);
 		// Fills in the second column in the field editor
 		new Label(parent, SWT.NONE);
 


### PR DESCRIPTION
Fixes #47 

Tested in a Windows 10 installation with the `org.eclipse.epsilon.examples.picto.ecore` project: enabling the new preference option allows seeing the `Stats` and `3D Inheritance` views (blank if the option is disabled).

Any option change requires closing and re-opening the Picto view(s) to instantiate the internal browser with the proper options.