### PR TITLE
EGL merging: O(n^2) to O(n)

### DIFF
--- a/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/merge/Merger.java
+++ b/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/merge/Merger.java
@@ -10,8 +10,11 @@
 package org.eclipse.epsilon.egl.merge;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
+
 import org.eclipse.epsilon.egl.merge.output.LocatedRegion;
 import org.eclipse.epsilon.egl.merge.output.Output;
 import org.eclipse.epsilon.egl.merge.output.RegionType;
@@ -81,7 +84,7 @@ public class Merger {
 	
 	public String mergeProtectedRegions() {
 		warnings.clear();
-		final List<String> idsPresentInGenerated = new LinkedList<>();
+		final Set<String> idsPresentInGenerated = new HashSet<>();
 		
 		for (LocatedRegion generatedRegion : generated.getLocatedRegions()) {
 			final LocatedRegion existingRegion = existing.getLocatedRegion(generatedRegion.getId());

--- a/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/merge/output/Output.java
+++ b/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/merge/output/Output.java
@@ -1,11 +1,13 @@
 /*******************************************************************************
- * Copyright (c) 2008 The University of York.
+ * Copyright (c) 2008-2024 The University of York.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  * 
  * Contributors:
  *     Louis Rose - initial API and implementation
+ *     Sam Harris - optimised region merging
+ *     Antonio Garcia-Dominguez - minor corrections
  ******************************************************************************/
 package org.eclipse.epsilon.egl.merge.output;
 
@@ -15,9 +17,8 @@ import java.util.stream.Collectors;
 public class Output {
 
 	private final List<Region> regions = new ArrayList<>(0);
-	private final Collection<String> locatedRegionIds = new LinkedHashSet<>();
 	private final Collection<String> duplicatedLocatedRegionIds = new LinkedHashSet<>();
-	private final Map<String, LocatedRegion> locatedRegionCache = new HashMap<>();
+	private final Map<String, LocatedRegion> locatedRegions = new HashMap<>();
 	
 	public Output(Region... regions) {
 		this(Arrays.asList(regions));	
@@ -33,12 +34,11 @@ public class Output {
 			if (r instanceof LocatedRegion) {
 				final LocatedRegion lr = (LocatedRegion) r;
 				final String id = lr.getId();
-				if (locatedRegionIds.contains(id)) {
+				if (locatedRegions.containsKey(id)) {
 					duplicatedLocatedRegionIds.add(id);
 				}
 				else {
-					locatedRegionIds.add(id);
-					locatedRegionCache.put(id, lr);
+					locatedRegions.put(id, lr);
 				}
 			}
 		}
@@ -56,7 +56,7 @@ public class Output {
 	}
 	
 	public LocatedRegion getLocatedRegion(String id) {
-		return locatedRegionCache.get(id);
+		return locatedRegions.get(id);
 	}
 	
 	public List<String> getProblems() {

--- a/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/merge/output/Output.java
+++ b/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/merge/output/Output.java
@@ -17,6 +17,7 @@ public class Output {
 	private final List<Region> regions = new ArrayList<>(0);
 	private final Collection<String> locatedRegionIds = new LinkedHashSet<>();
 	private final Collection<String> duplicatedLocatedRegionIds = new LinkedHashSet<>();
+	private final Map<String, LocatedRegion> locatedRegionCache = new HashMap<>();
 	
 	public Output(Region... regions) {
 		this(Arrays.asList(regions));	
@@ -37,6 +38,7 @@ public class Output {
 				}
 				else {
 					locatedRegionIds.add(id);
+					locatedRegionCache.put(id, lr);
 				}
 			}
 		}
@@ -54,16 +56,7 @@ public class Output {
 	}
 	
 	public LocatedRegion getLocatedRegion(String id) {
-		for (Region region : regions) {
-			if (region instanceof LocatedRegion) {
-				LocatedRegion locatedRegion = (LocatedRegion)region;
-				if (locatedRegion.getId().equals(id)) {
-					return locatedRegion;
-				}
-			}
-		}
-		
-		return null;
+		return locatedRegionCache.get(id);
 	}
 	
 	public List<String> getProblems() {


### PR DESCRIPTION
I recently worked on a project that had a file with about 6 thousand protected regions. It took about three minutes generate and merge. Currently the Merger loops through all of the LocatedRegions in the generated Output and in each iteration it searches for the matching existing region by looping through all of the LocatedRegions in the existing Output. This means that the inner loop was running about 36 million times (worst case). By caching the LocatedRegions in a HashMap, we can change the complexity from O(n^2) to O(n).

I also changed the `idsPresentInGenerated` LinkedList to a HashSet for the same reason.