### PR TITLE
EGL: partitioning performance improvements

### DIFF
--- a/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/merge/partition/CommentBlockPartitioner.java
+++ b/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/merge/partition/CommentBlockPartitioner.java
@@ -1,13 +1,17 @@
 /*******************************************************************************
- * Copyright (c) 2008 The University of York.
+ * Copyright (c) 2008-2024 The University of York.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  * 
  * Contributors:
  *     Louis Rose - initial API and implementation
+ *     Leo Mylonas - performance optimisation
+ *     Antonio Garcia-Dominguez - use capture group constants, other code cleanup
  ******************************************************************************/
 package org.eclipse.epsilon.egl.merge.partition;
+
+import static org.eclipse.epsilon.egl.util.FileUtil.NEWLINE;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -15,16 +19,22 @@ import java.util.Objects;
 import java.util.Scanner;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.eclipse.epsilon.egl.merge.output.Output;
+
 import org.eclipse.epsilon.egl.merge.output.LocatedRegion;
+import org.eclipse.epsilon.egl.merge.output.Output;
 import org.eclipse.epsilon.egl.merge.output.Region;
 import org.eclipse.epsilon.egl.merge.output.RegionType;
 import org.eclipse.epsilon.egl.util.FileUtil;
 
 public class CommentBlockPartitioner implements Partitioner {
-	
+
+	private static final int GROUP_REGION_TYPE = 1;
+	private static final int GROUP_REGION_ID = 2;
+	private static final int GROUP_END_OR_BEGIN = 3;
+	private static final int GROUP_ON_OR_OFF = 4;
+
 	private final String startComment, endComment;
-	private Pattern regionPattern;
+	private final Pattern regionPattern;
 	
 	private static String escape(String text) {
 		return text.replaceAll("\\*", "\\\\*");
@@ -33,14 +43,19 @@ public class CommentBlockPartitioner implements Partitioner {
 	public CommentBlockPartitioner(String startComment, String endComment) {
 		this.startComment = startComment == null ? "" : startComment;
 		this.endComment   = endComment   == null ? "" : endComment;
-		init();
+		this.regionPattern = initPattern();
 	}
-	
-	private void init() {
-		initPattern();
-	}
-	
-	private void initPattern() {
+
+	/**
+	 * Computes the regular expression used to match protected region start/end markers.
+	 * When editing this method, please maintain the {@code GROUP_*} constants up to date.
+	 *
+	 * @see #GROUP_REGION_ID
+	 * @see #GROUP_REGION_TYPE
+	 * @see #GROUP_END_OR_BEGIN
+	 * @see #GROUP_ON_OR_OFF
+	 */
+	protected Pattern initPattern() {
 		final StringBuilder regex = new StringBuilder();
 		
 		if (startComment.length() > 0) {
@@ -51,15 +66,15 @@ public class CommentBlockPartitioner implements Partitioner {
 			regex.append("[\\s]*");
 		}
 		
-		// The protected region literal
+		// The protected region literal (GROUP_REGION_TYPE)
 		regex.append("(controlled|protected) region ");
-		
-		// The region's id, matched reluctantly and terminated with a space
+
+		// The region's id, matched reluctantly and terminated with a space (GROUP_REGION_ID)
 		regex.append("(.*?) ");
 		
-		// end or (on or off followed by begin)
+		// end (GROUP_END_OR_BEGIN) or (on or off followed by begin, GROUP_ON_OR_OFF)
 		regex.append("(end|(on|off) begin)");
-		
+
 		if (endComment.length() > 0) {
 			// whitespace
 			regex.append("[\\s]*");
@@ -68,7 +83,7 @@ public class CommentBlockPartitioner implements Partitioner {
 			regex.append(escape(endComment));
 		}
 		
-		regionPattern = Pattern.compile(regex.toString());
+		return Pattern.compile(regex.toString());
 	}
 	
 	public String getStartComment() {
@@ -136,82 +151,81 @@ public class CommentBlockPartitioner implements Partitioner {
 	public Output partition(String text, int offset) {
 		final List<Region> regions = new LinkedList<>();
 
-		// We will read the text line by line, as this is the most performent way to process the text. 
-		final Scanner scanner = new Scanner(text);
-		final StringBuilder buffer = new StringBuilder();
-		
-		// Keep track of variables that will change as we read the text
-		boolean isRegionEnabled = false;
-		String regionId = null;
-		RegionType regionType = null;
-		int regionOffset = 0;
-		
-		// We need to keep a track of the offset within the text
-		int textOffset = 0;
-		
-		// Loop over each line
-		while (scanner.hasNextLine()) {
-			// Get the line (will not include line terminators)
-			String line = scanner.nextLine();
-			int currentLineOffset = 0;
-			
-			// Add the line terminators back in if appropriate
-			if (scanner.hasNextLine() || text.endsWith(System.lineSeparator())) {
-				line += System.lineSeparator();
-			}
-			
-			// Match the line against the region pattern
-			Matcher matcher = regionPattern.matcher(line);
-			
-			boolean didMatchPreviously = false;
-			while(true) {
-				boolean doesMatch = matcher.find();
-				
-				if (doesMatch) {
-					didMatchPreviously = true;
-					
-					// If there is any content before the region marker, add it to the buffer
-					if (currentLineOffset < matcher.start()) {
-						buffer.append(line.substring(currentLineOffset, matcher.start()));
-					}
-					
-					// Keep a track of where we are in the line
-					currentLineOffset = matcher.start();
-					
-					// This is a region marker
-					if (matcher.group(3).equals("end")) {
-						// This is the end of a region
-						
-						// Pull the contents from the buffer and reset it
-						final String regionContents = buffer.toString();
-						buffer.setLength(0);
-						
-						// Create the protected region
-						final LocatedRegion region = new CommentedProtectedRegion(regionId, regionOffset, isRegionEnabled, regionContents);
-						region.setType(regionType);
-						regions.add(region);
-						
-						// Keep a track of where we are in the line
-						currentLineOffset = matcher.end();
-					} else {
-						// This is the start of a region
-						isRegionEnabled = matcher.group(4) != null && matcher.group(4).equals("on");
-						regionType = regionTypeFromString(matcher.group(1));
-						regionId = matcher.group(2);
-						regionOffset = offset + textOffset + currentLineOffset;
-						
-						// If the buffer contains any content, create a region for it and reset it
-						if (buffer.length() > 0) {
-							regions.add(new Region(buffer.toString()));
-							buffer.setLength(0);
+		// We will read the text line by line, as this is the most performant way to process the text. 
+		try (final Scanner scanner = new Scanner(text)) {
+			final StringBuilder buffer = new StringBuilder();
+
+			// Keep track of variables that will change as we read the text
+			boolean isRegionEnabled = false;
+			String regionId = null;
+			RegionType regionType = null;
+			int regionOffset = 0;
+
+			// We need to keep a track of the offset within the text
+			int textOffset = 0;
+
+			// Loop over each line
+			while (scanner.hasNextLine()) {
+				// Get the line (will not include line terminators)
+				String line = scanner.nextLine();
+				int currentLineOffset = 0;
+
+				// Add the line terminators back in if appropriate
+				if (scanner.hasNextLine() || text.endsWith(NEWLINE)) {
+					line += NEWLINE;
+				}
+
+				// Match the line against the region pattern
+				Matcher matcher = regionPattern.matcher(line);
+
+				boolean doesMatch, didMatchPreviously = false;
+				do {
+					doesMatch = matcher.find();
+
+					if (doesMatch) {
+						didMatchPreviously = true;
+
+						// If there is any content before the region marker, add it to the buffer
+						if (currentLineOffset < matcher.start()) {
+							buffer.append(line.substring(currentLineOffset, matcher.start()));
 						}
-						
+
 						// Keep a track of where we are in the line
-						// There is always a new line at the end of a starting region
-						currentLineOffset = matcher.end() + System.lineSeparator().length();
-					}
-				} else {
-					if (didMatchPreviously) {
+						currentLineOffset = matcher.start();
+
+						// This is a region marker
+						if ("end".equals(matcher.group(GROUP_END_OR_BEGIN))) {
+							// This is the end of a region
+
+							// Pull the contents from the buffer and reset it
+							final String regionContents = buffer.toString();
+							buffer.setLength(0);
+
+							// Create the protected region
+							final LocatedRegion region = new CommentedProtectedRegion(regionId, regionOffset, isRegionEnabled, regionContents);
+							region.setType(regionType);
+							regions.add(region);
+
+							// Keep a track of where we are in the line
+							currentLineOffset = matcher.end();
+						} else {
+							// This is the start of a region
+							isRegionEnabled = "on".equals(matcher.group(GROUP_ON_OR_OFF));
+							regionType = regionTypeFromString(matcher.group(GROUP_REGION_TYPE));
+							regionId = matcher.group(GROUP_REGION_ID);
+							regionOffset = offset + textOffset + currentLineOffset;
+
+							// If the buffer contains any content, create a region for it and reset it
+							if (buffer.length() > 0) {
+								regions.add(new Region(buffer.toString()));
+								buffer.setLength(0);
+							}
+
+							// Keep a track of where we are in the line
+							// There is always a new line at the end of a starting region
+							currentLineOffset = matcher.end() + NEWLINE.length();
+						}
+					} else if (didMatchPreviously) {
 						// If there was a match on this line and there is additional content after the match, add it to the buffer
 						if (currentLineOffset < line.length()) {
 							buffer.append(line.substring(currentLineOffset));							
@@ -220,24 +234,19 @@ public class CommentBlockPartitioner implements Partitioner {
 						// Nothing on this line was matched, add the whole line to the buffer
 						buffer.append(line);
 					}
-					// Break out of the while loop as there are no more matches in this line
-					break;
-				}
+				} while (doesMatch);
+
+				// Increase the offset number
+				textOffset += line.length();
 			}
-			
-			// Increase the offset number
-			textOffset += line.length();
+
+			// If the buffer still has length, we need to add it as another region
+			if (buffer.length() > 0) {
+				regions.add(new Region(buffer.toString()));
+				buffer.setLength(0);
+			}
 		}
-		
-		// Close the scanner to release resources
-		scanner.close();
-		
-		// If the buffer still has length, we need to add it as another region
-		if (buffer.length() > 0) {
-			regions.add(new Region(buffer.toString()));
-			buffer.setLength(0);
-		}
-		
+
 		return new Output(regions);
 	}
 	

--- a/tests/org.eclipse.epsilon.egl.engine.test.unit/src/org/eclipse/epsilon/egl/merge/partition/TestCommentBlockPartitioner.java
+++ b/tests/org.eclipse.epsilon.egl.engine.test.unit/src/org/eclipse/epsilon/egl/merge/partition/TestCommentBlockPartitioner.java
@@ -99,8 +99,9 @@ public abstract class TestCommentBlockPartitioner {
 		                              startComment + "protected region test end" + endComment;
 		
 		final Output expected = new Output(partitioner.new CommentedProtectedRegion("test", 0, false, regionContents));
+		final Output actual = partitioner.partition(text);
 		
-		assertEquals(expected, partitioner.partition(text));
+		assertEquals(expected, actual);
 	}
 
 	public void testPartitionSingleProtectedRegionEmpty() {
@@ -148,8 +149,9 @@ public abstract class TestCommentBlockPartitioner {
 		                              unprotected;
 		
 		final Output expected = new Output(partitioner.new CommentedProtectedRegion("test", 0, true, regionContents), new Region(unprotected));
+		final Output actual = partitioner.partition(text);
 		
-		assertEquals(expected, partitioner.partition(text));
+		assertEquals(expected, actual);
 	}
 
 	public void testPartitionTwoProtectedRegions() {
@@ -165,8 +167,9 @@ public abstract class TestCommentBlockPartitioner {
 		
 		final Output expected = new Output(partitioner.new CommentedProtectedRegion("test",  0, true, firstRegionContents),
 		                                   partitioner.new CommentedProtectedRegion("test2", text.indexOf(startComment + "protected region test2"), true, secondRegionContents));
+		final Output actual = partitioner.partition(text);
 		
-		assertEquals(expected, partitioner.partition(text));
+		assertEquals(expected, actual);
 	}
 
 	public void testPartitionComplex() {

--- a/tests/org.eclipse.epsilon.egl.traceability.fine.test.acceptance/src/org/eclipse/epsilon/egl/engine/traceability/fine/test/acceptance/contributions/TemplateOperationsContributeToTrace.java
+++ b/tests/org.eclipse.epsilon.egl.traceability.fine.test.acceptance/src/org/eclipse/epsilon/egl/engine/traceability/fine/test/acceptance/contributions/TemplateOperationsContributeToTrace.java
@@ -1,5 +1,6 @@
 package org.eclipse.epsilon.egl.engine.traceability.fine.test.acceptance.contributions;
 
+import static org.eclipse.epsilon.egl.util.FileUtil.NEWLINE;
 import static org.eclipse.epsilon.test.util.builders.emf.EClassBuilder.anEClass;
 import static org.eclipse.epsilon.test.util.builders.emf.EPackageBuilder.aMetamodel;
 
@@ -13,14 +14,14 @@ public class TemplateOperationsContributeToTrace extends EglFineGrainedTraceabil
 	@Test
 	public void testTemplateOperationWithoutIndentation() throws Exception {
 		
-		String staticText = "Some static text\n";
+		String staticText = "Some static text\n".replaceAll("\n", NEWLINE);
 		
 		String egl = staticText +
 				"[%=t()%]\n  " + 
 				"[%@template   \n" +
 				"operation t(){%]\n" +
 				"[%=EClass.all.first.name%]\n" +
-				"[%}%]";
+				"[%}%]".replaceAll("\n", NEWLINE);
 		
 		EClass   person = anEClass().named("Person").build();
 		EPackage model  = aMetamodel().with(person).build();
@@ -32,7 +33,7 @@ public class TemplateOperationsContributeToTrace extends EglFineGrainedTraceabil
 	@Test
 	public void testTemplateOperationWithIndentation() throws Exception {
 		
-		String staticText = "Some static text\n";
+		String staticText = "Some static text\n".replaceAll("\n", NEWLINE);
 		
 		String egl = staticText +
 				"\t[%=t()%]\n  " + 
@@ -40,7 +41,7 @@ public class TemplateOperationsContributeToTrace extends EglFineGrainedTraceabil
 				"operation t(){%]\n" +
 				"[%for (c in EClass.all){%]" +
 				"[%=c.name%]\n" +
-				"[%}}%]";
+				"[%}}%]".replaceAll("\n", NEWLINE);
 		
 		EClass person = anEClass().named("Person").build();
 		EClass task = anEClass().named("Task").build();
@@ -48,12 +49,12 @@ public class TemplateOperationsContributeToTrace extends EglFineGrainedTraceabil
 		generateTrace(egl, model);
 		
 		trace.assertEquals(staticText.length() + 1, "Trace.all.first.traceLinks.first().destination.region.offset");
-		trace.assertEquals(staticText.length() + 1 + person.getName().length() + 2, "Trace.all.first.traceLinks.second().destination.region.offset");
+		trace.assertEquals(staticText.length() + 1 + person.getName().length() + 1 + NEWLINE.length(), "Trace.all.first.traceLinks.second().destination.region.offset");
 	}
 
 	@Test
 	public void testNestedTemplateOperationWithIndentation() throws Exception {
-		String staticText = "Some static text\n";
+		String staticText = "Some static text\n".replaceAll("\n", NEWLINE);
 		
 		String egl = staticText +
 				"	[%=t()%] \n"
@@ -65,7 +66,7 @@ public class TemplateOperationsContributeToTrace extends EglFineGrainedTraceabil
 				+ "@template\n"
 				+ "operation t2(c){%]\n"
 				+ "EClass [%=c.name%]\n"
-				+ "[%}%]\n";
+				+ "[%}%]\n".replaceAll("\n", NEWLINE);
 
 		EClass person = anEClass().named("Person").build();
 		EClass task = anEClass().named("Task").build();
@@ -73,7 +74,7 @@ public class TemplateOperationsContributeToTrace extends EglFineGrainedTraceabil
 		generateTrace(egl, model);
 
 		final int startOfFirstEClassName = staticText.length() + 1 + "EClass ".length();
-		final int startOfSecondEClassName = startOfFirstEClassName + person.getName().length() + 2 + "EClass ".length();
+		final int startOfSecondEClassName = startOfFirstEClassName + person.getName().length() + 1 + NEWLINE.length() + "EClass ".length();
 
 		trace.assertEquals(startOfFirstEClassName, "Trace.all.first.traceLinks.first().destination.region.offset");
 		trace.assertEquals(person.getName(), "Trace.all.first.traceLinks.first().destination.region.text");

--- a/tests/org.eclipse.epsilon.egx.engine.test.acceptance/src/org/eclipse/epsilon/egx/engine/test/acceptance/performance/EgxPerformanceTests.java
+++ b/tests/org.eclipse.epsilon.egx.engine.test.acceptance/src/org/eclipse/epsilon/egx/engine/test/acceptance/performance/EgxPerformanceTests.java
@@ -1,0 +1,129 @@
+package org.eclipse.epsilon.egx.engine.test.acceptance.performance;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Comparator;
+
+import org.eclipse.emf.ecore.plugin.EcorePlugin;
+import org.eclipse.epsilon.common.util.FileUtil;
+import org.eclipse.epsilon.egl.EgxModule;
+import org.eclipse.epsilon.egl.IEgxModule;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+@Ignore("Performance tests don't need to be part of the test suite")
+public class EgxPerformanceTests {
+
+	static File manyProtectedRegionEGX;
+	static Path outputRoot;
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+		outputRoot = Paths.get(FileUtil.getFileStandalone("", EgxPerformanceTests.class).toURI())
+				.resolve("" + Math.random());
+
+		if (!Files.exists(outputRoot)) {
+			Files.createDirectory(outputRoot);
+		}
+	}
+
+	@AfterClass
+	public static void tearDownAfterClass() throws IOException {
+		Files.walk(outputRoot).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+	}
+
+	@Test
+	public void test1000ProtectedRegions() throws Exception {
+		executeAndMeasureEgx(1000);
+	}
+
+	@Test
+	public void test2000ProtectedRegions() throws Exception {
+		executeAndMeasureEgx(2000);
+	}
+
+	@Test
+	public void test3000ProtectedRegions() throws Exception {
+		executeAndMeasureEgx(3000);
+	}
+
+	@Test
+	public void test4000ProtectedRegions() throws Exception {
+		executeAndMeasureEgx(4000);
+	}
+
+	@Test
+	public void test5000ProtectedRegions() throws Exception {
+		executeAndMeasureEgx(5000);
+	}
+
+	private void executeAndMeasureEgx(int numberOfProtectedRegions) throws Exception {
+		final Path egxPath = generateEgxAndEgl(numberOfProtectedRegions);
+
+		EcorePlugin.INSTANCE.log("Executing " + egxPath);
+
+		// Execute once for the initial generation
+		long start = System.currentTimeMillis();
+		IEgxModule module = new EgxModule(outputRoot);
+		module.parse(egxPath);
+		module.execute();
+
+		long firstExecution = System.currentTimeMillis();
+
+		// Execute again so the protected regions need to be merged
+		module = new EgxModule(outputRoot);
+		module.parse(egxPath);
+		module.execute();
+		long secondExecution = System.currentTimeMillis();
+
+		long firstExecutionTime = firstExecution - start;
+		long secondExecutionTime = secondExecution - firstExecution;
+		long executionPerProtectedRegion = secondExecutionTime / numberOfProtectedRegions;
+
+		EcorePlugin.INSTANCE.log("First execution took " + firstExecutionTime + " ms");
+		EcorePlugin.INSTANCE.log("Second execution took " + secondExecutionTime + " ms");
+		EcorePlugin.INSTANCE.log("Took " + executionPerProtectedRegion + " ms per protected region");
+
+		assertTrue("Slow execution detected", executionPerProtectedRegion < 5);
+	}
+
+	private Path generateEgxAndEgl(int numberOfProtectedRegions) throws IOException {
+		final Path outputPath = outputRoot.resolve(numberOfProtectedRegions + ".egx");
+
+		final StringBuilder builder = new StringBuilder();
+		builder.append("rule generate" + numberOfProtectedRegions + " {\n");
+		builder.append("  template : \"" + numberOfProtectedRegions + ".egl\"\n");
+		builder.append("  target : \"" + numberOfProtectedRegions + ".txt\"\n");
+		builder.append("}\n");
+
+		Files.write(outputPath, builder.toString().getBytes());
+
+		generateEgl(numberOfProtectedRegions);
+
+		return outputPath;
+	}
+
+	private Path generateEgl(int numberOfProtectedRegions) throws IOException {
+		final Path outputPath = outputRoot.resolve(numberOfProtectedRegions + ".egl");
+
+		final StringBuilder builder = new StringBuilder();
+		builder.append("[% out.setContentType('Java'); %]\n");
+		builder.append("This file containes " + numberOfProtectedRegions + " protected regions.\n");
+
+		for (int i = 0; i < numberOfProtectedRegions; i++) {
+			builder.append("[%=out.startPreserve('region" + i + "', false)%]\n");
+			builder.append("[%=out.stopPreserve()%]\n");
+		}
+
+		Files.write(outputPath, builder.toString().getBytes());
+
+		return outputPath;
+	}
+}


### PR DESCRIPTION
We found an exponential increase in the time it takes to generate files based on the number of protected regions. This PR rewrites the `CommentBlockPartitioner` to be much more performant.

Some benchmarks below

![image](https://github.com/eclipse/epsilon/assets/671045/6da8a103-625d-4b15-9d1c-fde8e4ea5e7b)