### PR TITLE
[EolModule] ImportManager for caching imports

### DIFF
--- a/examples/org.eclipse.epsilon.edl.engine/src/org/eclipse/epsilon/edl/EdlModule.java
+++ b/examples/org.eclipse.epsilon.edl.engine/src/org/eclipse/epsilon/edl/EdlModule.java
@@ -88,8 +88,8 @@ public class EdlModule extends EolModule {
 	}
 
 	@Override
-	public HashMap<String, Class<?>> getImportConfiguration() {
-		HashMap<String, Class<?>> importConfiguration = super.getImportConfiguration();
+	public HashMap<String, Class<? extends IModule>> getImportConfiguration() {
+		HashMap<String, Class<? extends IModule>> importConfiguration = super.getImportConfiguration();
 		importConfiguration.put("edl", EdlModule.class);
 		return importConfiguration;
 	}

--- a/plugins/org.eclipse.epsilon.ecl.engine/src/org/eclipse/epsilon/ecl/EclModule.java
+++ b/plugins/org.eclipse.epsilon.ecl.engine/src/org/eclipse/epsilon/ecl/EclModule.java
@@ -98,8 +98,8 @@ public class EclModule extends ErlModule implements IEclModule {
 	}
 	
 	@Override
-	public HashMap<String, Class<?>> getImportConfiguration() {
-		HashMap<String, Class<?>> importConfiguration = super.getImportConfiguration();
+	public HashMap<String, Class<? extends IModule>> getImportConfiguration() {
+		HashMap<String, Class<? extends IModule>> importConfiguration = super.getImportConfiguration();
 		importConfiguration.put("ecl", EclModule.class);
 		return importConfiguration;
 	}

--- a/plugins/org.eclipse.epsilon.ecl.engine/src/org/eclipse/epsilon/ecl/concurrent/EclModuleParallel.java
+++ b/plugins/org.eclipse.epsilon.ecl.engine/src/org/eclipse/epsilon/ecl/concurrent/EclModuleParallel.java
@@ -13,6 +13,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
+import org.eclipse.epsilon.common.module.IModule;
 import org.eclipse.epsilon.ecl.EclModule;
 import org.eclipse.epsilon.ecl.execute.context.concurrent.*;
 import org.eclipse.epsilon.eol.execute.context.concurrent.IEolContextParallel;
@@ -40,8 +42,8 @@ public abstract class EclModuleParallel extends EclModule {
 	}
 	
 	@Override
-	public HashMap<String, Class<?>> getImportConfiguration() {
-		HashMap<String, Class<?>> importConfiguration = super.getImportConfiguration();
+	public HashMap<String, Class<? extends IModule>> getImportConfiguration() {
+		HashMap<String, Class<? extends IModule>> importConfiguration = super.getImportConfiguration();
 		importConfiguration.put("ecl", EclModuleParallelAnnotation.class);
 		return importConfiguration;
 	}

--- a/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/EglFileGeneratingTemplate.java
+++ b/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/EglFileGeneratingTemplate.java
@@ -15,6 +15,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.stream.Collectors;
+
 import org.eclipse.epsilon.common.util.UriUtil;
 import org.eclipse.epsilon.egl.exceptions.EglRuntimeException;
 import org.eclipse.epsilon.egl.execute.context.IEglContext;
@@ -30,6 +31,7 @@ import org.eclipse.epsilon.egl.spec.EglTemplateSpecificationFactory;
 import org.eclipse.epsilon.egl.status.ProtectedRegionWarning;
 import org.eclipse.epsilon.egl.traceability.OutputFile;
 import org.eclipse.epsilon.egl.util.FileUtil;
+import org.eclipse.epsilon.eol.ImportManager;
 
 public class EglFileGeneratingTemplate extends EglPersistentTemplate {
 
@@ -47,7 +49,7 @@ public class EglFileGeneratingTemplate extends EglPersistentTemplate {
 	
 	// For tests
 	protected EglFileGeneratingTemplate(URI path, IEglContext context, URI outputRoot) throws Exception {
-		this(new EglTemplateSpecificationFactory(new NullFormatter(), new IncrementalitySettings()).fromResource(path.toString(), path), context, outputRoot);
+		this(new EglTemplateSpecificationFactory(new NullFormatter(), new IncrementalitySettings(), new ImportManager()).fromResource(path.toString(), path), context, outputRoot);
 	}
 
 	public EglFileGeneratingTemplate(EglTemplateSpecification spec, IEglContext context, URI outputRoot, String outputRootPath) throws Exception {

--- a/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/EglModule.java
+++ b/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/EglModule.java
@@ -29,6 +29,7 @@ import org.eclipse.epsilon.common.parse.problem.ParseProblem;
 import org.eclipse.epsilon.egl.execute.context.IEglContext;
 import org.eclipse.epsilon.egl.formatter.Formatter;
 import org.eclipse.epsilon.eol.IEolModule;
+import org.eclipse.epsilon.eol.IImportManager;
 import org.eclipse.epsilon.eol.dom.Import;
 import org.eclipse.epsilon.eol.dom.ModelDeclaration;
 import org.eclipse.epsilon.eol.dom.OperationList;
@@ -278,5 +279,16 @@ public class EglModule implements IEglModule {
 	public Map<String, Object> getData() {
 		return current.getModule().getData();
 	}
+
+	@Override
+	public IImportManager getImportManager() {
+		return current.module.getImportManager();
+	}
+
+	@Override
+	public void setImportManager(IImportManager importManager) {
+		current.module.setImportManager(importManager);
+	}
+
 
 }

--- a/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/EglTemplate.java
+++ b/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/EglTemplate.java
@@ -32,6 +32,8 @@ import org.eclipse.epsilon.egl.spec.EglTemplateSpecification;
 import org.eclipse.epsilon.egl.spec.EglTemplateSpecificationFactory;
 import org.eclipse.epsilon.egl.status.ProtectedRegionWarning;
 import org.eclipse.epsilon.egl.traceability.Template;
+import org.eclipse.epsilon.eol.IImportManager;
+import org.eclipse.epsilon.eol.ImportManager;
 import org.eclipse.epsilon.eol.dom.Import;
 import org.eclipse.epsilon.eol.dom.ModelDeclaration;
 import org.eclipse.epsilon.eol.dom.OperationList;
@@ -50,16 +52,17 @@ public class EglTemplate {
 	
 	// For tests
 	EglTemplate(URI path, IEglContext context) throws Exception {
-		this(new EglTemplateSpecificationFactory(new NullFormatter(), new IncrementalitySettings()).fromResource(path.toString(), path), context);
+		this(new EglTemplateSpecificationFactory(new NullFormatter(), new IncrementalitySettings(), new ImportManager()).fromResource(path.toString(), path), context);
 	}
 
 	public EglTemplate(EglTemplateSpecification spec, IEglContext context) throws Exception {
-		this(spec.getName(), context, spec.createTemplate(), spec.getDefaultFormatter(), spec.getIncrementalitySettings(), spec.getTemplateExecutionListeners());
+		this(spec.getName(), context, spec.createTemplate(), spec.getDefaultFormatter(), spec.getIncrementalitySettings(), spec.getTemplateExecutionListeners(), spec.getImportManager());
 		spec.parseInto(module);
 	}
 	
-	private EglTemplate(String name, IEglContext context, Template template, Formatter formatter, IncrementalitySettings incrementalitySettings, Collection<ITemplateExecutionListener> listeners) {
+	private EglTemplate(String name, IEglContext context, Template template, Formatter formatter, IncrementalitySettings incrementalitySettings, Collection<ITemplateExecutionListener> listeners, IImportManager importManager) {
 		this.module = new EglModule(context);
+		this.module.setImportManager(importManager);
 		this.name     = name;
 		this.template = template;
 		this.formatter = formatter;

--- a/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/EglTemplateFactory.java
+++ b/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/EglTemplateFactory.java
@@ -1,11 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2008 The University of York.
+ * Copyright (c) 2008-2024 The University of York.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  * 
  * Contributors:
  *     Louis Rose - initial API and implementation
+ *     Antonio Garcia-Dominguez - add import caching via import manager
  ******************************************************************************/
 package org.eclipse.epsilon.egl;
 
@@ -16,6 +17,7 @@ import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedList;
+
 import org.eclipse.epsilon.common.util.UriUtil;
 import org.eclipse.epsilon.egl.exceptions.EglRuntimeException;
 import org.eclipse.epsilon.egl.execute.context.EglContext;
@@ -28,6 +30,8 @@ import org.eclipse.epsilon.egl.incremental.IncrementalitySettings;
 import org.eclipse.epsilon.egl.spec.EglTemplateSpecification;
 import org.eclipse.epsilon.egl.spec.EglTemplateSpecificationFactory;
 import org.eclipse.epsilon.egl.util.FileUtil;
+import org.eclipse.epsilon.eol.IImportManager;
+import org.eclipse.epsilon.eol.ImportManager;
 import org.eclipse.epsilon.eol.execute.context.IEolContext;
 import org.eclipse.epsilon.eol.execute.context.concurrent.IEolContextParallel;
 
@@ -40,7 +44,8 @@ public class EglTemplateFactory {
 	private Formatter defaultFormatter = new NullFormatter();
 	private IncrementalitySettings defaultIncrementalitySettings = new IncrementalitySettings();
 	private final Collection<ITemplateExecutionListener> listeners = new LinkedList<>();
-	
+	private IImportManager importManager = new ImportManager();
+
 	public EglTemplateFactory() {
 		this(null);
 	}
@@ -76,7 +81,14 @@ public class EglTemplateFactory {
 	public void setContext(IEglContext context) {
 		this.context = context;
 	}
-	
+
+	public IImportManager getImportManager() {
+		return importManager;
+	}
+
+	public void setImportManager(IImportManager importManager) {
+		this.importManager = importManager;
+	}
 
 	/**
 	 * Sets the root of this template factory, unless it has already been set.
@@ -269,7 +281,7 @@ public class EglTemplateFactory {
 	
 	private EglTemplateSpecificationFactory createTemplateSpecificationFactory() {
 		return new EglTemplateSpecificationFactory(
-			defaultFormatter, defaultIncrementalitySettings,
+			defaultFormatter, defaultIncrementalitySettings, importManager,
 			listeners.toArray(new ITemplateExecutionListener[listeners.size()])
 		);
 	}

--- a/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/EgxModule.java
+++ b/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/EgxModule.java
@@ -206,8 +206,8 @@ public class EgxModule extends ErlModule implements IEgxModule {
 	}
 	
 	@Override
-	public HashMap<String, Class<?>> getImportConfiguration() {
-		HashMap<String, Class<?>> importConfiguration = super.getImportConfiguration();
+	public HashMap<String, Class<? extends IModule>> getImportConfiguration() {
+		HashMap<String, Class<? extends IModule>> importConfiguration = super.getImportConfiguration();
 		importConfiguration.put("egx", EgxModule.class);
 		return importConfiguration;
 	}

--- a/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/concurrent/EgxModuleParallel.java
+++ b/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/concurrent/EgxModuleParallel.java
@@ -14,6 +14,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
+import org.eclipse.epsilon.common.module.IModule;
 import org.eclipse.epsilon.egl.EgxModule;
 import org.eclipse.epsilon.egl.exceptions.EglRuntimeException;
 import org.eclipse.epsilon.egl.execute.context.concurrent.EgxContextParallel;
@@ -52,8 +54,8 @@ public abstract class EgxModuleParallel extends EgxModule {
 	}
 	
 	@Override
-	public HashMap<String, Class<?>> getImportConfiguration() {
-		HashMap<String, Class<?>> importConfiguration = super.getImportConfiguration();
+	public HashMap<String, Class<? extends IModule>> getImportConfiguration() {
+		HashMap<String, Class<? extends IModule>> importConfiguration = super.getImportConfiguration();
 		importConfiguration.put("egx", EgxModuleParallelAnnotation.class);
 		return importConfiguration;
 	}

--- a/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/internal/EglModule.java
+++ b/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/internal/EglModule.java
@@ -226,8 +226,8 @@ public class EglModule extends EolModule implements IEglModule {
 	}
 	
 	@Override
-	protected HashMap<String, Class<?>> getImportConfiguration() {
-		HashMap<String, Class<?>> importConfiguration = super.getImportConfiguration();
+	protected HashMap<String, Class<? extends IModule>> getImportConfiguration() {
+		HashMap<String, Class<? extends IModule>> importConfiguration = super.getImportConfiguration();
 		importConfiguration.put("egl", EglModule.class);
 		return importConfiguration;
 	}

--- a/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/spec/CodeBackedTemplateSpecification.java
+++ b/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/spec/CodeBackedTemplateSpecification.java
@@ -11,18 +11,20 @@ package org.eclipse.epsilon.egl.spec;
 
 import java.net.URI;
 import java.util.Collection;
+
 import org.eclipse.epsilon.egl.execute.control.ITemplateExecutionListener;
 import org.eclipse.epsilon.egl.formatter.Formatter;
 import org.eclipse.epsilon.egl.incremental.IncrementalitySettings;
 import org.eclipse.epsilon.egl.internal.IEglModule;
 import org.eclipse.epsilon.egl.traceability.Template;
+import org.eclipse.epsilon.eol.IImportManager;
 
 class CodeBackedTemplateSpecification extends EglTemplateSpecification {
 
 	private final String code;
 	
-	protected CodeBackedTemplateSpecification(String code, Formatter defaultFormatter, IncrementalitySettings incrementalitySettings, Collection<ITemplateExecutionListener> listeners) {
-		super("Anonymous", defaultFormatter, incrementalitySettings, listeners);
+	protected CodeBackedTemplateSpecification(String code, Formatter defaultFormatter, IncrementalitySettings incrementalitySettings, IImportManager importManager, Collection<ITemplateExecutionListener> listeners) {
+		super("Anonymous", defaultFormatter, incrementalitySettings, importManager, listeners);
 		
 		this.code = code;
 	}

--- a/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/spec/DirtyResourceBackedTemplateSpecification.java
+++ b/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/spec/DirtyResourceBackedTemplateSpecification.java
@@ -12,19 +12,21 @@ package org.eclipse.epsilon.egl.spec;
 import java.io.File;
 import java.net.URI;
 import java.util.Collection;
+
 import org.eclipse.epsilon.egl.execute.control.ITemplateExecutionListener;
 import org.eclipse.epsilon.egl.formatter.Formatter;
 import org.eclipse.epsilon.egl.incremental.IncrementalitySettings;
 import org.eclipse.epsilon.egl.internal.IEglModule;
 import org.eclipse.epsilon.egl.traceability.Template;
+import org.eclipse.epsilon.eol.IImportManager;
 
 class DirtyResourceBackedTemplateSpecification extends EglTemplateSpecification {
 
 	private final String latestCode;
 	private final URI resource;
 	
-	protected DirtyResourceBackedTemplateSpecification(String name, String latestCode, URI resource, Formatter defaultFormatter, IncrementalitySettings incrementalitySettings, Collection<ITemplateExecutionListener> listeners) {
-		super(name, defaultFormatter, incrementalitySettings, listeners);
+	protected DirtyResourceBackedTemplateSpecification(String name, String latestCode, URI resource, Formatter defaultFormatter, IncrementalitySettings incrementalitySettings, IImportManager importManager, Collection<ITemplateExecutionListener> listeners) {
+		super(name, defaultFormatter, incrementalitySettings, importManager, listeners);
 		
 		this.latestCode = latestCode;
 		this.resource = resource;

--- a/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/spec/EglTemplateSpecification.java
+++ b/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/spec/EglTemplateSpecification.java
@@ -1,22 +1,25 @@
 /*******************************************************************************
- * Copyright (c) 2011 The University of York.
+ * Copyright (c) 2011-2024 The University of York.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  * 
  * Contributors:
  *     Louis Rose - initial API and implementation
+ *     Antonio Garcia-Dominguez - add import managers
  ******************************************************************************/
 package org.eclipse.epsilon.egl.spec;
 
 import java.net.URI;
 import java.util.Collection;
 import java.util.LinkedList;
+
 import org.eclipse.epsilon.egl.execute.control.ITemplateExecutionListener;
 import org.eclipse.epsilon.egl.formatter.Formatter;
 import org.eclipse.epsilon.egl.incremental.IncrementalitySettings;
 import org.eclipse.epsilon.egl.internal.IEglModule;
 import org.eclipse.epsilon.egl.traceability.Template;
+import org.eclipse.epsilon.eol.IImportManager;
 
 public abstract class EglTemplateSpecification {
 
@@ -24,12 +27,14 @@ public abstract class EglTemplateSpecification {
 	private final Formatter defaultFormatter;
 	private final IncrementalitySettings incrementalitySettings;
 	private final Collection<ITemplateExecutionListener> listeners;
+	private final IImportManager importManager;
 	
-	protected EglTemplateSpecification(String name, Formatter defaultFormatter, IncrementalitySettings incrementalitySettings, Collection<ITemplateExecutionListener> listeners) {
+	protected EglTemplateSpecification(String name, Formatter defaultFormatter, IncrementalitySettings incrementalitySettings, IImportManager importManager, Collection<ITemplateExecutionListener> listeners) {
 		this.name = name;
 		this.defaultFormatter = defaultFormatter;
 		this.incrementalitySettings = incrementalitySettings;
 		this.listeners = listeners;
+		this.importManager = importManager;
 	}
 	
 	public String getName() {
@@ -38,6 +43,10 @@ public abstract class EglTemplateSpecification {
 	
 	public Formatter getDefaultFormatter() {
 		return defaultFormatter;
+	}
+
+	public IImportManager getImportManager() {
+		return importManager;
 	}
 	
 	public IncrementalitySettings getIncrementalitySettings() {

--- a/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/spec/EglTemplateSpecificationFactory.java
+++ b/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/spec/EglTemplateSpecificationFactory.java
@@ -1,11 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2011 The University of York.
+ * Copyright (c) 2011-2024 The University of York.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
  * 
  * Contributors:
  *     Louis Rose - initial API and implementation
+ *     Antonio Garcia-Dominguez - add import managers
  ******************************************************************************/
 package org.eclipse.epsilon.egl.spec;
 
@@ -16,28 +17,31 @@ import java.util.Collection;
 import org.eclipse.epsilon.egl.execute.control.ITemplateExecutionListener;
 import org.eclipse.epsilon.egl.formatter.Formatter;
 import org.eclipse.epsilon.egl.incremental.IncrementalitySettings;
+import org.eclipse.epsilon.eol.IImportManager;
 
 public class EglTemplateSpecificationFactory {
 
 	private final Formatter defaultFormatter;
 	private final IncrementalitySettings incrementalitySettings;
 	private final Collection<ITemplateExecutionListener> listeners;
+	private final IImportManager importManager;
 	
-	public EglTemplateSpecificationFactory(Formatter defaultFormatter, IncrementalitySettings incrementalitySettings, ITemplateExecutionListener... listeners) {
+	public EglTemplateSpecificationFactory(Formatter defaultFormatter, IncrementalitySettings incrementalitySettings, IImportManager importManager, ITemplateExecutionListener... listeners) {
 		this.defaultFormatter = defaultFormatter;
 		this.incrementalitySettings = incrementalitySettings;
 		this.listeners = Arrays.asList(listeners);
+		this.importManager = importManager;
 	}
 	
 	public EglTemplateSpecification fromCode(String code) {
-		return new CodeBackedTemplateSpecification(code, defaultFormatter, incrementalitySettings, listeners);
+		return new CodeBackedTemplateSpecification(code, defaultFormatter, incrementalitySettings, importManager, listeners);
 	}
 
 	public EglTemplateSpecification fromResource(String name, URI resource) {
-		return new ResourceBackedTemplateSpecification(name, resource, defaultFormatter, incrementalitySettings, listeners);
+		return new ResourceBackedTemplateSpecification(name, resource, defaultFormatter, incrementalitySettings, importManager, listeners);
 	}
 
 	public EglTemplateSpecification fromDirtyResource(String name, String latestCode, URI resource) {
-		return new DirtyResourceBackedTemplateSpecification(name, latestCode, resource, defaultFormatter, incrementalitySettings, listeners);
+		return new DirtyResourceBackedTemplateSpecification(name, latestCode, resource, defaultFormatter, incrementalitySettings, importManager, listeners);
 	}
 }

--- a/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/spec/ResourceBackedTemplateSpecification.java
+++ b/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/spec/ResourceBackedTemplateSpecification.java
@@ -16,13 +16,14 @@ import org.eclipse.epsilon.egl.formatter.Formatter;
 import org.eclipse.epsilon.egl.incremental.IncrementalitySettings;
 import org.eclipse.epsilon.egl.internal.IEglModule;
 import org.eclipse.epsilon.egl.traceability.Template;
+import org.eclipse.epsilon.eol.IImportManager;
 
 class ResourceBackedTemplateSpecification extends EglTemplateSpecification {
 
 	private final URI resource;
 	
-	protected ResourceBackedTemplateSpecification(String name, URI resource, Formatter defaultFormatter, IncrementalitySettings incrementalitySettings, Collection<ITemplateExecutionListener> listeners) {
-		super(name, defaultFormatter, incrementalitySettings, listeners);
+	protected ResourceBackedTemplateSpecification(String name, URI resource, Formatter defaultFormatter, IncrementalitySettings incrementalitySettings, IImportManager importManager, Collection<ITemplateExecutionListener> listeners) {
+		super(name, defaultFormatter, incrementalitySettings, importManager, listeners);
 		
 		this.resource = resource;
 	}

--- a/plugins/org.eclipse.epsilon.emg.engine/src/org/eclipse/epsilon/emg/EmgModule.java
+++ b/plugins/org.eclipse.epsilon.emg.engine/src/org/eclipse/epsilon/emg/EmgModule.java
@@ -17,6 +17,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.eclipse.epsilon.common.module.IModule;
 import org.eclipse.epsilon.emg.execute.operations.contributors.EmgOperationContributor;
 import org.eclipse.epsilon.eol.dom.Annotation;
 import org.eclipse.epsilon.eol.dom.AnnotationBlock;
@@ -136,8 +138,8 @@ public class EmgModule extends EplModule implements IEmgModule {
 	 * @see org.eclipse.epsilon.epl.EplModule#getImportConfiguration()
 	 */
 	@Override
-	public HashMap<String, Class<?>> getImportConfiguration() {
-		HashMap<String, Class<?>> importConfiguration = super.getImportConfiguration();
+	public HashMap<String, Class<? extends IModule>> getImportConfiguration() {
+		HashMap<String, Class<? extends IModule>> importConfiguration = super.getImportConfiguration();
 		importConfiguration.put("emg", EmgModule.class);
 		return importConfiguration;
 	}

--- a/plugins/org.eclipse.epsilon.eml.engine/src/org/eclipse/epsilon/eml/EmlModule.java
+++ b/plugins/org.eclipse.epsilon.eml.engine/src/org/eclipse/epsilon/eml/EmlModule.java
@@ -67,8 +67,8 @@ public class EmlModule extends EtlModule implements IEmlModule {
 	}
 
 	@Override
-	public HashMap<String, Class<?>> getImportConfiguration() {
-		HashMap<String, Class<?>> importConfiguration = super.getImportConfiguration();
+	public HashMap<String, Class<? extends IModule>> getImportConfiguration() {
+		HashMap<String, Class<? extends IModule>> importConfiguration = super.getImportConfiguration();
 		importConfiguration.put("eml", EmlModule.class);
 		return importConfiguration;
 	}

--- a/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/EolModule.java
+++ b/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/EolModule.java
@@ -126,7 +126,7 @@ public class EolModule extends AbstractModule implements IEolModule {
 		super.build(cst, module);
 		checkImports(cst);
 		
-		for (Map.Entry<String, Class<?>> entry : getImportConfiguration().entrySet()) {
+		for (Map.Entry<String, Class<?  extends IModule>> entry : getImportConfiguration().entrySet()) {
 			imports.addAll(getImportsByExtension(cst, entry.getKey(), entry.getValue()));
 		}
 		
@@ -334,8 +334,8 @@ public class EolModule extends AbstractModule implements IEolModule {
 		return declaredOperations;
 	}
 	
-	protected HashMap<String, Class<?>> getImportConfiguration() {
-		HashMap<String, Class<?>> importConfiguration = new HashMap<>(4);
+	protected HashMap<String, Class<? extends IModule>> getImportConfiguration() {
+		HashMap<String, Class<? extends IModule>> importConfiguration = new HashMap<>(4);
 		importConfiguration.put("eol", EolModule.class);
 		return importConfiguration;
 	}
@@ -385,7 +385,7 @@ public class EolModule extends AbstractModule implements IEolModule {
 		return operations;
 	}
 	
-	protected Collection<Import> getImportsByExtension(AST cst, String extension, Class<?> moduleImplClass) {
+	protected Collection<Import> getImportsByExtension(AST cst, String extension, Class<? extends IModule> moduleImplClass) {
 		List<AST> importAsts = AstUtil.getChildren(cst, EolParser.IMPORT);
 		List<Import> imports = new ArrayList<>(importAsts.size());
 		

--- a/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/IEolModule.java
+++ b/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/IEolModule.java
@@ -75,4 +75,8 @@ public interface IEolModule extends IModule {
 	default Set<String> getConfigurationProperties() {
 		return Collections.emptySet();
 	}
+	
+	IImportManager getImportManager();
+	
+	void setImportManager(IImportManager importManager);
 }

--- a/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/IImportManager.java
+++ b/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/IImportManager.java
@@ -1,0 +1,13 @@
+package org.eclipse.epsilon.eol;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.eclipse.epsilon.common.module.IModule;
+import org.eclipse.epsilon.eol.dom.Import;
+
+public interface IImportManager {
+	
+	void loadModuleForImport(Import importAst, Class<? extends IModule> moduleImplClass, URI baseURI) throws URISyntaxException;
+
+}

--- a/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/ImportManager.java
+++ b/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/ImportManager.java
@@ -29,8 +29,7 @@ public class ImportManager implements IImportManager {
 			try {
 				module = moduleImplClass.getDeclaredConstructor().newInstance();
 			} catch (Exception e) {
-				e.printStackTrace();
-				return;
+				throw new RuntimeException(e);
 			}
 			
 			/*

--- a/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/ImportManager.java
+++ b/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/ImportManager.java
@@ -1,0 +1,64 @@
+package org.eclipse.epsilon.eol;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.epsilon.common.module.IModule;
+import org.eclipse.epsilon.common.util.UriUtil;
+import org.eclipse.epsilon.eol.dom.Import;
+
+public class ImportManager implements IImportManager {
+	
+	protected Map<URI, IModule> cache = new HashMap<>();
+
+	@Override
+	public void loadModuleForImport(Import import_, Class<? extends IModule> moduleImplClass, URI baseURI) throws URISyntaxException {
+		String importPath = import_.getPath();
+
+		final URI importUri = UriUtil.resolve(importPath, baseURI).normalize();
+		final IEolModule parentModule = import_.getParentModule();
+		
+		IModule module = cache.get(importUri);
+		if (module != null) {
+			import_.setImportedModule(module);
+			import_.setLoaded(true);
+		}
+		else {
+			try {
+				module = moduleImplClass.getDeclaredConstructor().newInstance();
+			} catch (Exception e) {
+				e.printStackTrace();
+				return;
+			}
+			
+			/*
+			 * The module must be added to the cache before import_.load is called,
+			 * otherwise there will be infinite recursion in the case of circular import.
+			 */
+			cache.put(importUri, module);
+
+			/*
+			 * If possible, ensure child modules share this import manager so the cache is
+			 * most effective.
+			 */
+			if (module instanceof IEolModule) {
+				IEolModule eolModule = (IEolModule) module;
+				eolModule.setImportManager(this);
+
+				/*
+				 * Parent module must be set, to allow things like ETL overriding the way in
+				 * which ::= works in imported EOL modules.
+				 */
+				eolModule.setParentModule(parentModule);
+			}
+			
+			import_.setImportedModule(module);
+
+			// Use existing import loading logic
+			import_.load(baseURI);
+		}
+	}
+
+}

--- a/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/concurrent/EolModuleParallel.java
+++ b/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/concurrent/EolModuleParallel.java
@@ -13,6 +13,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
+import org.eclipse.epsilon.common.module.IModule;
 import org.eclipse.epsilon.eol.EolModule;
 import org.eclipse.epsilon.eol.execute.context.concurrent.EolContextParallel;
 import org.eclipse.epsilon.eol.execute.context.concurrent.IEolContextParallel;
@@ -38,8 +40,8 @@ public class EolModuleParallel extends EolModule {
 	}
 	
 	@Override
-	protected HashMap<String, Class<?>> getImportConfiguration() {
-		HashMap<String, Class<?>> importConfiguration = super.getImportConfiguration();
+	protected HashMap<String, Class<? extends IModule>> getImportConfiguration() {
+		HashMap<String, Class<? extends IModule>> importConfiguration = super.getImportConfiguration();
 		importConfiguration.put("eol", EolModuleParallel.class);
 		return importConfiguration;
 	}

--- a/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/dom/Import.java
+++ b/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/dom/Import.java
@@ -26,7 +26,11 @@ public class Import extends AbstractModuleElement {
 	private boolean loaded = false;
 	private boolean found = false;
 	protected StringLiteral pathLiteral;
-	
+
+	public IEolModule getParentModule() {
+		return parentModule;
+	}
+
 	public void setParentModule(IEolModule parentModule) {
 		this.parentModule = parentModule;
 	}
@@ -101,6 +105,10 @@ public class Import extends AbstractModuleElement {
 	
 	public boolean isLoaded() {
 		return loaded;
+	}
+
+	public void setLoaded(boolean loaded) {
+		this.loaded = loaded;
 	}
 	
 	public boolean isFound() {

--- a/plugins/org.eclipse.epsilon.epl.engine/src/org/eclipse/epsilon/epl/AbstractEplModule.java
+++ b/plugins/org.eclipse.epsilon.epl.engine/src/org/eclipse/epsilon/epl/AbstractEplModule.java
@@ -93,8 +93,8 @@ public abstract class AbstractEplModule extends ErlModule implements IEplModule 
 	}
 	
 	@Override
-	public HashMap<String, Class<?>> getImportConfiguration() {
-		HashMap<String, Class<?>> importConfiguration = super.getImportConfiguration();
+	public HashMap<String, Class<?  extends IModule>> getImportConfiguration() {
+		HashMap<String, Class<? extends IModule>> importConfiguration = super.getImportConfiguration();
 		importConfiguration.put("epl", getClass());
 		return importConfiguration;
 	}

--- a/plugins/org.eclipse.epsilon.epl.engine/src/org/eclipse/epsilon/epl/concurrent/EplModuleParallel.java
+++ b/plugins/org.eclipse.epsilon.epl.engine/src/org/eclipse/epsilon/epl/concurrent/EplModuleParallel.java
@@ -13,6 +13,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
+import org.eclipse.epsilon.common.module.IModule;
 import org.eclipse.epsilon.eol.execute.context.concurrent.IEolContextParallel;
 import org.eclipse.epsilon.epl.EplModule;
 import org.eclipse.epsilon.epl.execute.context.concurrent.EplContextParallel;
@@ -40,8 +42,8 @@ public class EplModuleParallel extends EplModule {
 	}
 	
 	@Override
-	public HashMap<String, Class<?>> getImportConfiguration() {
-		HashMap<String, Class<?>> importConfiguration = super.getImportConfiguration();
+	public HashMap<String, Class<? extends IModule>> getImportConfiguration() {
+		HashMap<String, Class<? extends IModule>> importConfiguration = super.getImportConfiguration();
 		importConfiguration.put("epl", EplModuleParallel.class);
 		return importConfiguration;
 	}

--- a/plugins/org.eclipse.epsilon.erl.engine/src/org/eclipse/epsilon/erl/ErlModule.java
+++ b/plugins/org.eclipse.epsilon.erl.engine/src/org/eclipse/epsilon/erl/ErlModule.java
@@ -102,8 +102,8 @@ public class ErlModule extends EolModule implements IErlModule {
 	}
 	
 	@Override
-	public HashMap<String, Class<?>> getImportConfiguration() {
-		HashMap<String, Class<?>> importConfiguration = super.getImportConfiguration();
+	public HashMap<String, Class<? extends IModule>> getImportConfiguration() {
+		HashMap<String, Class<? extends IModule>> importConfiguration = super.getImportConfiguration();
 		importConfiguration.put("erl", ErlModule.class);
 		return importConfiguration;
 	}

--- a/plugins/org.eclipse.epsilon.erl.engine/src/org/eclipse/epsilon/erl/concurrent/ErlModuleParallel.java
+++ b/plugins/org.eclipse.epsilon.erl.engine/src/org/eclipse/epsilon/erl/concurrent/ErlModuleParallel.java
@@ -13,6 +13,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
+import org.eclipse.epsilon.common.module.IModule;
 import org.eclipse.epsilon.eol.execute.context.concurrent.IEolContextParallel;
 import org.eclipse.epsilon.erl.ErlModule;
 import org.eclipse.epsilon.erl.execute.context.concurrent.ErlContextParallel;
@@ -39,8 +41,8 @@ public class ErlModuleParallel extends ErlModule {
 	}
 	
 	@Override
-	public HashMap<String, Class<?>> getImportConfiguration() {
-		HashMap<String, Class<?>> importConfiguration = super.getImportConfiguration();
+	public HashMap<String, Class<? extends IModule>> getImportConfiguration() {
+		HashMap<String, Class<? extends IModule>> importConfiguration = super.getImportConfiguration();
 		importConfiguration.put("erl", ErlModuleParallel.class);
 		return importConfiguration;
 	}

--- a/plugins/org.eclipse.epsilon.etl.engine/src/org/eclipse/epsilon/etl/EtlModule.java
+++ b/plugins/org.eclipse.epsilon.etl.engine/src/org/eclipse/epsilon/etl/EtlModule.java
@@ -142,8 +142,8 @@ public class EtlModule extends ErlModule implements IEtlModule {
 	}
 	
 	@Override
-	public HashMap<String, Class<?>> getImportConfiguration() {
-		HashMap<String, Class<?>> importConfiguration = super.getImportConfiguration();
+	public HashMap<String, Class<? extends IModule>> getImportConfiguration() {
+		HashMap<String, Class<? extends IModule>> importConfiguration = super.getImportConfiguration();
 		importConfiguration.put("etl", EtlModule.class);
 		return importConfiguration;
 	}

--- a/plugins/org.eclipse.epsilon.evl.engine/src/org/eclipse/epsilon/evl/EvlModule.java
+++ b/plugins/org.eclipse.epsilon.evl.engine/src/org/eclipse/epsilon/evl/EvlModule.java
@@ -100,8 +100,8 @@ public class EvlModule extends ErlModule implements IEvlModule {
 	}
 
 	@Override
-	public HashMap<String, Class<?>> getImportConfiguration() {
-		HashMap<String, Class<?>> importConfiguration = super.getImportConfiguration();
+	public HashMap<String, Class<? extends IModule>> getImportConfiguration() {
+		HashMap<String, Class<? extends IModule>> importConfiguration = super.getImportConfiguration();
 		importConfiguration.put("evl", EvlModule.class);
 		return importConfiguration;
 	}

--- a/plugins/org.eclipse.epsilon.evl.engine/src/org/eclipse/epsilon/evl/concurrent/EvlModuleParallel.java
+++ b/plugins/org.eclipse.epsilon.evl.engine/src/org/eclipse/epsilon/evl/concurrent/EvlModuleParallel.java
@@ -13,6 +13,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
+import org.eclipse.epsilon.common.module.IModule;
 import org.eclipse.epsilon.eol.exceptions.EolRuntimeException;
 import org.eclipse.epsilon.eol.execute.context.concurrent.IEolContextParallel;
 import org.eclipse.epsilon.evl.EvlModule;
@@ -35,8 +37,8 @@ public abstract class EvlModuleParallel extends EvlModule {
 	}
 	
 	@Override
-	public HashMap<String, Class<?>> getImportConfiguration() {
-		HashMap<String, Class<?>> importConfiguration = super.getImportConfiguration();
+	public HashMap<String, Class<? extends IModule>> getImportConfiguration() {
+		HashMap<String, Class<? extends IModule>> importConfiguration = super.getImportConfiguration();
 		importConfiguration.put("evl", EvlModuleParallelAnnotation.class);
 		return importConfiguration;
 	}

--- a/plugins/org.eclipse.epsilon.pinset.engine/src/org/eclipse/epsilon/pinset/PinsetModule.java
+++ b/plugins/org.eclipse.epsilon.pinset.engine/src/org/eclipse/epsilon/pinset/PinsetModule.java
@@ -100,8 +100,8 @@ public class PinsetModule extends ErlModule {
 	}
 
 	@Override
-	public HashMap<String, Class<?>> getImportConfiguration() {
-		HashMap<String, Class<?>> importConfiguration = super.getImportConfiguration();
+	public HashMap<String, Class<? extends IModule>> getImportConfiguration() {
+		HashMap<String, Class<? extends IModule>> importConfiguration = super.getImportConfiguration();
 		importConfiguration.put("pinset", PinsetModule.class);
 		return importConfiguration;
 	}

--- a/tests/org.eclipse.epsilon.egl.engine.test.acceptance/src/org/eclipse/epsilon/egl/test/acceptance/EglAcceptanceTestSuite.java
+++ b/tests/org.eclipse.epsilon.egl.engine.test.acceptance/src/org/eclipse/epsilon/egl/test/acceptance/EglAcceptanceTestSuite.java
@@ -9,9 +9,6 @@
  ******************************************************************************/
 package org.eclipse.epsilon.egl.test.acceptance;
 
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-
 import org.eclipse.epsilon.egl.test.acceptance.engine.Engine;
 import org.eclipse.epsilon.egl.test.acceptance.engine.reset.ResettingTemplates;
 import org.eclipse.epsilon.egl.test.acceptance.engine.subtemplates.InvokingSubtemplates;
@@ -19,6 +16,7 @@ import org.eclipse.epsilon.egl.test.acceptance.eol.ConsistencyWithEolSuite;
 import org.eclipse.epsilon.egl.test.acceptance.exceptions.Exceptions;
 import org.eclipse.epsilon.egl.test.acceptance.extensibility.Extensibility;
 import org.eclipse.epsilon.egl.test.acceptance.formatters.Formatters;
+import org.eclipse.epsilon.egl.test.acceptance.importCaching.ImportCachingTests;
 import org.eclipse.epsilon.egl.test.acceptance.merge.Merge;
 import org.eclipse.epsilon.egl.test.acceptance.operations.template.TemplateOperations;
 import org.eclipse.epsilon.egl.test.acceptance.outdentation.OutdentationTests;
@@ -31,6 +29,9 @@ import org.eclipse.epsilon.egl.test.acceptance.traceability.Traceability;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
+
+import junit.framework.JUnit4TestAdapter;
+import junit.framework.Test;
 
 @RunWith(Suite.class)
 @SuiteClasses({Engine.class,
@@ -47,7 +48,8 @@ import org.junit.runners.Suite.SuiteClasses;
                CurrentLineNumber.class,
                Formatters.class,
                PatchTestSuite.class,
-               OutdentationTests.class})
+               OutdentationTests.class,
+               ImportCachingTests.class})
 public class EglAcceptanceTestSuite {
 
 	public static Test suite() {

--- a/tests/org.eclipse.epsilon.egl.engine.test.acceptance/src/org/eclipse/epsilon/egl/test/acceptance/importCaching/ImportCachingTests.java
+++ b/tests/org.eclipse.epsilon.egl.engine.test.acceptance/src/org/eclipse/epsilon/egl/test/acceptance/importCaching/ImportCachingTests.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Antonio García-Domínguez.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors:
+ *     Antonio García-Domínguez - initial API and implementation
+******************************************************************************/
+package org.eclipse.epsilon.egl.test.acceptance.importCaching;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import java.io.File;
+import java.net.URI;
+import java.util.List;
+
+import org.eclipse.epsilon.common.util.FileUtil;
+import org.eclipse.epsilon.egl.EglTemplate;
+import org.eclipse.epsilon.egl.EglTemplateFactory;
+import org.eclipse.epsilon.egl.EgxModule;
+import org.eclipse.epsilon.egl.exceptions.EglRuntimeException;
+import org.eclipse.epsilon.eol.IEolModule;
+import org.eclipse.epsilon.eol.dom.Import;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests that ensure that import caching works as intended.
+ */
+public class ImportCachingTests {
+
+	private static File mainEGX;
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+		Class<?> relClass = ImportCachingTests.class;
+
+		// Load dependencies
+		mainEGX = FileUtil.getFileStandalone("main.egx", relClass);
+		FileUtil.getFileStandalone("first.egl", relClass);
+		FileUtil.getFileStandalone("second.egl", relClass);
+		FileUtil.getFileStandalone("utils.eol", relClass);
+	}
+
+	@Test
+	public void reusedEOL() throws Exception {
+		EgxModule module = new EgxModule();
+		module.parse(mainEGX);
+
+		IEolModule firstImported;
+		{
+			EglTemplate firstTemplate = loadTemplate(module, "first.egl");
+			List<Import> firstImports = firstTemplate.getModule().getImports();
+			assertEquals(1, firstImports.size());
+			firstImported = (IEolModule) firstImports.get(0).getImportedModule();
+		}
+
+		IEolModule secondImported;
+		{
+			EglTemplate secondTemplate = loadTemplate(module, "second.egl");
+			List<Import> secondImports = secondTemplate.getModule().getImports();
+			assertEquals(1, secondImports.size());
+			secondImported = (IEolModule) secondImports.get(0).getImportedModule();
+		}
+
+		assertSame("Both EGL templates should reuse the same EOL module instance",
+			firstImported, secondImported);
+	}
+
+	private EglTemplate loadTemplate(EgxModule module, String templateName) throws EglRuntimeException {
+		EglTemplateFactory templateFactory = module.getContext().getTemplateFactory();
+		URI templateUri = templateFactory.resolveTemplate(templateName);
+		EglTemplate eglTemplate = templateFactory.load(templateUri);
+		return eglTemplate;
+	}
+
+}

--- a/tests/org.eclipse.epsilon.egl.engine.test.acceptance/src/org/eclipse/epsilon/egl/test/acceptance/importCaching/first.egl
+++ b/tests/org.eclipse.epsilon.egl.engine.test.acceptance/src/org/eclipse/epsilon/egl/test/acceptance/importCaching/first.egl
@@ -1,0 +1,2 @@
+[% import 'utils.eol'; %]
+First!

--- a/tests/org.eclipse.epsilon.egl.engine.test.acceptance/src/org/eclipse/epsilon/egl/test/acceptance/importCaching/main.egx
+++ b/tests/org.eclipse.epsilon.egl.engine.test.acceptance/src/org/eclipse/epsilon/egl/test/acceptance/importCaching/main.egx
@@ -1,0 +1,7 @@
+rule FirstRule transform o: Any {
+  template: 'first.egl'
+}
+
+rule SecondRule transform o: Any {
+  template: 'second.egl'
+}

--- a/tests/org.eclipse.epsilon.egl.engine.test.acceptance/src/org/eclipse/epsilon/egl/test/acceptance/importCaching/second.egl
+++ b/tests/org.eclipse.epsilon.egl.engine.test.acceptance/src/org/eclipse/epsilon/egl/test/acceptance/importCaching/second.egl
@@ -1,0 +1,2 @@
+[% import 'utils.eol'; %]
+Second!

--- a/tests/org.eclipse.epsilon.egl.engine.test.acceptance/src/org/eclipse/epsilon/egl/test/acceptance/importCaching/utils.eol
+++ b/tests/org.eclipse.epsilon.egl.engine.test.acceptance/src/org/eclipse/epsilon/egl/test/acceptance/importCaching/utils.eol
@@ -1,0 +1,1 @@
+// nothing here

--- a/tests/org.eclipse.epsilon.eol.engine.test.acceptance/src/org/eclipse/epsilon/eol/engine/test/acceptance/EolAcceptanceTestSuite.java
+++ b/tests/org.eclipse.epsilon.eol.engine.test.acceptance/src/org/eclipse/epsilon/eol/engine/test/acceptance/EolAcceptanceTestSuite.java
@@ -22,6 +22,7 @@ import org.eclipse.epsilon.eol.engine.test.acceptance.exceptions.ExceptionTests;
 import org.eclipse.epsilon.eol.engine.test.acceptance.firstOrder.*;
 import org.eclipse.epsilon.eol.engine.test.acceptance.firstOrder.lambda.*;
 import org.eclipse.epsilon.eol.engine.test.acceptance.firstOrder.nested.*;
+import org.eclipse.epsilon.eol.engine.test.acceptance.importCaching.ImportCachingTests;
 import org.eclipse.epsilon.eol.engine.test.acceptance.recording.*;
 import org.eclipse.epsilon.eol.engine.test.acceptance.unparser.EolUnparserTests;
 import org.junit.runner.RunWith;
@@ -77,7 +78,8 @@ import org.junit.runners.Suite.SuiteClasses;
 	EolUnparserTests.class,
 	BreakAndContinueTests.class,
 	EnumResolutionTests.class,
-	CircularImportTests.class
+	CircularImportTests.class,
+	ImportCachingTests.class
 })
 public class EolAcceptanceTestSuite {
 
@@ -85,3 +87,4 @@ public class EolAcceptanceTestSuite {
 		return new junit.extensions.RepeatedTest(new JUnit4TestAdapter(EolAcceptanceTestSuite.class), 10);
 	}
 }
+

--- a/tests/org.eclipse.epsilon.eol.engine.test.acceptance/src/org/eclipse/epsilon/eol/engine/test/acceptance/importCaching/ImportCachingTests.java
+++ b/tests/org.eclipse.epsilon.eol.engine.test.acceptance/src/org/eclipse/epsilon/eol/engine/test/acceptance/importCaching/ImportCachingTests.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Antonio García-Domínguez.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * Contributors:
+ *     Antonio García-Domínguez - initial API and implementation
+******************************************************************************/
+package org.eclipse.epsilon.eol.engine.test.acceptance.importCaching;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import java.io.File;
+
+import org.eclipse.epsilon.common.util.FileUtil;
+import org.eclipse.epsilon.eol.EolModule;
+import org.eclipse.epsilon.eol.IEolModule;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests that ensure that import caching works as intended.
+ */
+public class ImportCachingTests {
+
+	private static File mainEOL;
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+		Class<?> relClass = ImportCachingTests.class;
+
+		// Load dependencies
+		mainEOL = FileUtil.getFileStandalone("main.eol", relClass);
+		FileUtil.getFileStandalone("b.eol", relClass);
+		FileUtil.getFileStandalone("c.eol", relClass);
+	}
+
+	@Test
+	public void reusedEOL() throws Exception {
+		EolModule module = new EolModule();
+		module.parse(mainEOL);
+
+		assertEquals("main.eol should import 2 modules", 2, module.getImports().size());
+		IEolModule bModule = (IEolModule) module.getImports().get(0).getImportedModule();
+		IEolModule cModule = (IEolModule) module.getImports().get(1).getImportedModule();
+		assertEquals("First import in main.eol should be b.eol", "b.eol", bModule.getFile().getName());
+		assertEquals("Second import in main.eol should be c.eol", "c.eol", cModule.getFile().getName());
+
+		assertEquals("b.eol should import 1 module", 1, bModule.getImports().size());
+		assertSame("main.eol and b.eol should reuse the same instance of c.eol",
+			cModule, bModule.getImports().get(0).getImportedModule());
+	}
+
+}

--- a/tests/org.eclipse.epsilon.eol.engine.test.acceptance/src/org/eclipse/epsilon/eol/engine/test/acceptance/importCaching/b.eol
+++ b/tests/org.eclipse.epsilon.eol.engine.test.acceptance/src/org/eclipse/epsilon/eol/engine/test/acceptance/importCaching/b.eol
@@ -1,0 +1,1 @@
+import 'c.eol';

--- a/tests/org.eclipse.epsilon.eol.engine.test.acceptance/src/org/eclipse/epsilon/eol/engine/test/acceptance/importCaching/c.eol
+++ b/tests/org.eclipse.epsilon.eol.engine.test.acceptance/src/org/eclipse/epsilon/eol/engine/test/acceptance/importCaching/c.eol
@@ -1,0 +1,1 @@
+// no imports

--- a/tests/org.eclipse.epsilon.eol.engine.test.acceptance/src/org/eclipse/epsilon/eol/engine/test/acceptance/importCaching/main.eol
+++ b/tests/org.eclipse.epsilon.eol.engine.test.acceptance/src/org/eclipse/epsilon/eol/engine/test/acceptance/importCaching/main.eol
@@ -1,0 +1,2 @@
+import 'b.eol';
+import 'c.eol';

--- a/tests/org.eclipse.epsilon.etl.engine.test.acceptance/src/org/eclipse/epsilon/etl/engine/test/acceptance/EtlAcceptanceTestSuite.java
+++ b/tests/org.eclipse.epsilon.etl.engine.test.acceptance/src/org/eclipse/epsilon/etl/engine/test/acceptance/EtlAcceptanceTestSuite.java
@@ -1,33 +1,35 @@
 /*******************************************************************************
- * Copyright (c) 2009 The University of York.
+ * Copyright (c) 2009-2024 The University of York.
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
  * 
  * Contributors:
  *     Louis Rose - initial API and implementation
- ******************************************************************************
- *
- * $Id$
- */
+ *     Antonio Garcia-Dominguez - add import caching tests
+ ******************************************************************************/
 package org.eclipse.epsilon.etl.engine.test.acceptance;
 
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-
 import org.eclipse.epsilon.etl.engine.test.acceptance.builtins.EtlCanAccessBuiltinsTests;
+import org.eclipse.epsilon.etl.engine.test.acceptance.importCaching.ImportCachingTests;
 import org.eclipse.epsilon.etl.engine.test.acceptance.oo2db.OO2DBTest;
 import org.eclipse.epsilon.etl.engine.test.acceptance.tree2graph.Tree2GraphTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import junit.framework.JUnit4TestAdapter;
+import junit.framework.Test;
+
 @RunWith(Suite.class)
 @SuiteClasses({
 	EtlCanAccessBuiltinsTests.class,
 	TransformationRuleTests.class,
 	OO2DBTest.class,
-	Tree2GraphTest.class
+	Tree2GraphTest.class,
+	ImportCachingTests.class
 })
 public class EtlAcceptanceTestSuite {
 

--- a/tests/org.eclipse.epsilon.etl.engine.test.acceptance/src/org/eclipse/epsilon/etl/engine/test/acceptance/importCaching/ImportCachingTests.java
+++ b/tests/org.eclipse.epsilon.etl.engine.test.acceptance/src/org/eclipse/epsilon/etl/engine/test/acceptance/importCaching/ImportCachingTests.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2024 The University of York.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Antonio García-Domínguez - initial API and implementation
+******************************************************************************/
+package org.eclipse.epsilon.etl.engine.test.acceptance.importCaching;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.epsilon.common.module.ModuleElement;
+import org.eclipse.epsilon.common.util.FileUtil;
+import org.eclipse.epsilon.eol.IEolModule;
+import org.eclipse.epsilon.eol.dom.Operation;
+import org.eclipse.epsilon.eol.dom.SpecialAssignmentStatement;
+import org.eclipse.epsilon.eol.dom.Statement;
+import org.eclipse.epsilon.etl.EtlModule;
+import org.eclipse.epsilon.etl.dom.EquivalentAssignmentStatement;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests that ensure that import caching works as intended.
+ */
+public class ImportCachingTests {
+
+	private static File mainETL;
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+		Class<?> relClass = ImportCachingTests.class;
+
+		// Load dependencies
+		mainETL = FileUtil.getFileStandalone("main.etl", relClass);
+		FileUtil.getFileStandalone("b.eol", relClass);
+		FileUtil.getFileStandalone("c.eol", relClass);
+	}
+
+	@Test
+	public void reusedEOLFromETL() throws Exception {
+		EtlModule etlModule = new EtlModule();
+		etlModule.parse(mainETL);
+
+		assertEquals("main.eol should import 2 modules", 2, etlModule.getImports().size());
+		IEolModule bModule = (IEolModule) etlModule.getImports().get(0).getImportedModule();
+		IEolModule cModuleFromETL = (IEolModule) etlModule.getImports().get(1).getImportedModule();
+		assertEquals("First import in main.eol should be b.eol", "b.eol", bModule.getFile().getName());
+		assertEquals("Second import in main.eol should be c.eol", "c.eol", cModuleFromETL.getFile().getName());
+
+		assertEquals("b.eol should import 1 module", 1, bModule.getImports().size());
+		IEolModule cModuleFromEOL = (IEolModule) bModule.getImports().get(0).getImportedModule();
+		assertSame("main.etl and b.eol should reuse the same instance of c.eol", cModuleFromETL, cModuleFromEOL);
+
+		Map<Class<?>, Set<Object>> nodesByTypeFromEOL = getOperationNodesByType(cModuleFromEOL);
+		assertEquals("In an EOL file imported from an EOL file imported by an ETL file, ::= is not a SpecialAssignmentOperator",
+			0, nodesByTypeFromEOL.getOrDefault(SpecialAssignmentStatement.class, Collections.emptySet()).size());
+		assertEquals("In an EOL file imported from an EOL file imported by an ETL file, ::= is an EquivalentAssignmentOperator",
+			1, nodesByTypeFromEOL.getOrDefault(EquivalentAssignmentStatement.class, Collections.emptySet()).size());
+	}
+
+	protected Map<Class<?>, Set<Object>> getOperationNodesByType(IEolModule module) {
+		Map<Class<?>, Set<Object>> results = new HashMap<>();
+		for (Operation op : module.getOperations()) {
+			for (Statement st : op.getBody().getStatements()) {
+				addNodesByType(results, st);
+			}
+		}
+		return results;
+	}
+
+	private void addNodesByType(Map<Class<?>, Set<Object>> results, ModuleElement e) {
+		results.computeIfAbsent(e.getClass(), k -> new HashSet<>()).add(e);
+		for (ModuleElement child : e.getChildren()) {
+			addNodesByType(results, child);
+		}
+	}
+
+}

--- a/tests/org.eclipse.epsilon.etl.engine.test.acceptance/src/org/eclipse/epsilon/etl/engine/test/acceptance/importCaching/b.eol
+++ b/tests/org.eclipse.epsilon.etl.engine.test.acceptance/src/org/eclipse/epsilon/etl/engine/test/acceptance/importCaching/b.eol
@@ -1,0 +1,1 @@
+import 'c.eol';

--- a/tests/org.eclipse.epsilon.etl.engine.test.acceptance/src/org/eclipse/epsilon/etl/engine/test/acceptance/importCaching/c.eol
+++ b/tests/org.eclipse.epsilon.etl.engine.test.acceptance/src/org/eclipse/epsilon/etl/engine/test/acceptance/importCaching/c.eol
@@ -1,0 +1,9 @@
+// no imports
+
+operation Any test() {
+  /*
+   * This should be a plain assignment when imported from EOL, and an
+   * equivalent statement when imported from ETL.
+   */
+  a ::= b;
+}

--- a/tests/org.eclipse.epsilon.etl.engine.test.acceptance/src/org/eclipse/epsilon/etl/engine/test/acceptance/importCaching/main.etl
+++ b/tests/org.eclipse.epsilon.etl.engine.test.acceptance/src/org/eclipse/epsilon/etl/engine/test/acceptance/importCaching/main.etl
@@ -1,0 +1,2 @@
+import 'b.eol';
+import 'c.eol';


### PR DESCRIPTION
Initial proof of concept for an ImportManager that caches imports.

I have tried to implement this with minimal changes to existing code although the import mechanism could be a candidate for a bigger refactor. 

Also, I have not yet implemented sharing the ImportManager between EGL templates run from EGX. I not sure where the best place to inject the ImportManager into the EGL modules/rule would be.

Feedback would be appreciated. Thanks!