### PR TITLE
Protected region regex pattern matching fails when `end` is used in the region ID

### DIFF
--- a/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/merge/partition/CommentBlockPartitioner.java
+++ b/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/merge/partition/CommentBlockPartitioner.java
@@ -3,7 +3,7 @@
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * Contributors:
  *     Louis Rose - initial API and implementation
  *     Leo Mylonas - performance optimisation
@@ -41,7 +41,7 @@ public class CommentBlockPartitioner implements Partitioner {
 	private static String escape(String text) {
 		return text.replaceAll("\\*", "\\\\*");
 	}
-	
+
 	public CommentBlockPartitioner(String startComment, String endComment) {
 		this.startComment = startComment == null ? "" : startComment;
 		this.endComment = endComment == null ? "" : endComment;
@@ -58,11 +58,11 @@ public class CommentBlockPartitioner implements Partitioner {
 	 */
 	protected Pattern initRegionPattern() {
 		final StringBuilder regex = new StringBuilder();
-		
+
 		if (startComment.length() > 0) {
 			// The start comment delimiter
 			regex.append(escape(startComment));
-			
+
 			// whitespace
 			regex.append("[\\s]*");
 		}
@@ -106,7 +106,7 @@ public class CommentBlockPartitioner implements Partitioner {
 		if (endComment.length() > 0) {
 			// whitespace
 			regex.append("[\\s]*");
-	
+
 			// The end comment delimiter
 			regex.append(escape(endComment));
 		}
@@ -116,33 +116,33 @@ public class CommentBlockPartitioner implements Partitioner {
 
 		return Pattern.compile(regex.toString());
 	}
-	
+
 	public String getStartComment() {
 		return startComment;
 	}
-	
+
 	public String getEndComment() {
 		return endComment;
 	}
-	
+
 	public String getFirstLine(String id, boolean enabled, RegionType regionType) {
 		final StringBuilder builder = new StringBuilder();
-		
+
 		// Build starting comment
 		if (startComment.length() > 0) {
 			builder.append(startComment).append(' ');
 		}
-		
+
 		builder.append(regionTypeToString(regionType) + " region ")
 			.append(id)
 			.append(" ")
 			.append(enabled ? "on" : "off")
 			.append(" begin");
-		
+
 		if (endComment.length() > 0) {
 			builder.append(' ').append(endComment);
 		}
-		
+
 		return builder.toString();
 	}
 
@@ -150,39 +150,39 @@ public class CommentBlockPartitioner implements Partitioner {
 		if (regionType == RegionType.Controlled) return "controlled";
 		else return "protected";
 	}
-	
+
 	protected RegionType regionTypeFromString(String regionType) {
 		if ("controlled".equals(regionType)) return RegionType.Controlled;
 		else return RegionType.Protected;
 	}
-	
+
 	public String getLastLine(String id, RegionType regionType) {
 		final StringBuilder builder = new StringBuilder();
-		
+
 		// Build ending comment
 		if (startComment.length() > 0) {
 			builder.append(startComment).append(' ');
 		}
-		
+
 		builder.append(regionTypeToString(regionType) + " region ")
 			.append(id)
 			.append(" end");
-		
+
 		if (endComment.length() > 0) {
 			builder.append(' ').append(endComment);
 		}
-		
+
 		return builder.toString();
 	}
-	
+
 	public Output partition(String text) {
 		return partition(text, 0);
 	}
-	
+
 	public Output partition(String text, int offset) {
 		final List<Region> regions = new LinkedList<>();
 
-		// We will read the text line by line, as this is the most performant way to process the text. 
+		// We will read the text line by line, as this is the most performant way to process the text.
 		try (final Scanner scanner = new Scanner(text)) {
 			final StringBuilder buffer = new StringBuilder();
 
@@ -213,22 +213,26 @@ public class CommentBlockPartitioner implements Partitioner {
 					// Nothing on this line was matched, add the whole line to the buffer
 					buffer.append(line);
 				} else {
-					// Loop over the matches in a more traditional style, since one match needs
-					// context
-					// as to if there are additional matches or not.
+					/*
+					 * Loop over the matches in a more traditional style, since one match needs
+					 * context as to if there are additional matches or not.
+					 */
 					for (int i = 0; i < regionMatches.size(); i++) {
 
 						// Get this region and (maybe) the next one
 						final RegionMatch regionMatch = regionMatches.get(i);
-						final RegionMatch nextRegionMatch = i + 1 < regionMatches.size() ? regionMatches.get(i + 1)
+						final RegionMatch nextRegionMatch = i + 1 < regionMatches.size()
+								? regionMatches.get(i + 1)
 								: null;
 
-						// The region starts and the start of the match
+						// The region starts at the start of the match
 						final int regionStartIndex = regionMatch.getStart();
 						// The ID of the region starts where the region match ends
 						final int regionIdStartIndex = regionMatch.getEnd();
-						// The region will either end at the begging of the next region, or the end of
-						// the line
+						/*
+						 * The region will either end at the beginning of the next region, or the end of
+						 * the line.
+						 */
 						final int regionEndIndex = nextRegionMatch == null ? line.length() : nextRegionMatch.getStart();
 
 						// If there is any content before the match, add it to the buffer
@@ -239,8 +243,10 @@ public class CommentBlockPartitioner implements Partitioner {
 						// Keep a track of where we are in the line
 						currentLineOffset = regionStartIndex;
 
-						// Extract out the region ID and start/end marks (and possible postamble) from
-						// the line for this region
+						/*
+						 * Extract out the region ID and start/end marks (and possible postamble) from
+						 * the line for this region.
+						 */
 						final String lineSegment = line.substring(regionIdStartIndex, regionEndIndex);
 						Matcher regionIdMatcher = regionIdPattern.matcher(lineSegment);
 
@@ -322,28 +328,28 @@ public class CommentBlockPartitioner implements Partitioner {
 
 	@Override
 	public String toString() {
-		return this.getClass().getSimpleName() + 
-		       "{start=\"" + startComment + "\", " + 
-		       "end=\"" + endComment + "\"}";
+		return this.getClass().getSimpleName() +
+			"{start=\"" + startComment + "\", " +
+			"end=\"" + endComment + "\"}";
 	}
-	
+
 	@Override
 	public boolean equals(Object o) {
 		if (!(o instanceof CommentBlockPartitioner))
 			return false;
-		
+
 		final CommentBlockPartitioner that = (CommentBlockPartitioner)o;
-		
+
 		return Objects.equals(this.startComment, that.startComment) &&
-		       Objects.equals(this.endComment, that.endComment);
+			Objects.equals(this.endComment, that.endComment);
 	}
-	
+
 	@Override
 	public int hashCode() {
 		return Objects.hash(startComment, endComment);
 	}
-	
-	
+
+
 	class CommentedProtectedRegion extends LocatedRegion {
 
 		CommentedProtectedRegion(String id, int offset, boolean enabled, String contents) {

--- a/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/merge/partition/CommentBlockPartitioner.java
+++ b/plugins/org.eclipse.epsilon.egl.engine/src/org/eclipse/epsilon/egl/merge/partition/CommentBlockPartitioner.java
@@ -233,7 +233,7 @@ public class CommentBlockPartitioner implements Partitioner {
 						 * The region will either end at the beginning of the next region, or the end of
 						 * the line.
 						 */
-						final int regionEndIndex = nextRegionMatch == null ? line.length() : nextRegionMatch.getStart();
+						final int regionIdEndIndex = nextRegionMatch == null ? line.length() : nextRegionMatch.getStart();
 
 						// If there is any content before the match, add it to the buffer
 						if (currentLineOffset < regionStartIndex) {
@@ -247,8 +247,8 @@ public class CommentBlockPartitioner implements Partitioner {
 						 * Extract out the region ID and start/end marks (and possible postamble) from
 						 * the line for this region.
 						 */
-						final String lineSegment = line.substring(regionIdStartIndex, regionEndIndex);
-						Matcher regionIdMatcher = regionIdPattern.matcher(lineSegment);
+						final String regionIdSegment = line.substring(regionIdStartIndex, regionIdEndIndex);
+						Matcher regionIdMatcher = regionIdPattern.matcher(regionIdSegment);
 
 						if (regionIdMatcher.find()) {
 							// This is a region marker

--- a/tests/org.eclipse.epsilon.egl.engine.test.acceptance/src/org/eclipse/epsilon/egl/test/acceptance/merge/Merge.java
+++ b/tests/org.eclipse.epsilon.egl.engine.test.acceptance/src/org/eclipse/epsilon/egl/test/acceptance/merge/Merge.java
@@ -133,11 +133,13 @@ public class Merge {
 		assertTrue("Expected warning for protected region 'sleep'",   sleepWarningFound);
 	}
 	
-	private static void assertEquals(File expected, File actual) throws IOException {
-		assertEquals(org.eclipse.epsilon.egl.util.FileUtil.read(expected), actual);
+	private static void assertEquals(File expectedFile, File actualFile) throws IOException {
+		final String expected = org.eclipse.epsilon.egl.util.FileUtil.read(expectedFile);
+		assertEquals(expected, expectedFile);
 	}
 	
-	private static void assertEquals(String expected, File actual) throws IOException {
-		org.junit.Assert.assertEquals(expected, org.eclipse.epsilon.egl.util.FileUtil.read(actual));
+	private static void assertEquals(String expected, File actualFile) throws IOException {
+		final String actual = org.eclipse.epsilon.egl.util.FileUtil.read(actualFile);
+		org.junit.Assert.assertEquals(expected, actual);
 	}
 }

--- a/tests/org.eclipse.epsilon.egl.engine.test.unit/src/org/eclipse/epsilon/egl/TestEglTemplate.java
+++ b/tests/org.eclipse.epsilon.egl.engine.test.unit/src/org/eclipse/epsilon/egl/TestEglTemplate.java
@@ -139,7 +139,9 @@ public class TestEglTemplate {
 		
 		template = new EglTemplate(UriUtil.fileToUri(MERGE), context);
 		
-		assertEquals(expected, template.merge(FileUtil.read(EXISTING)));
+		final String actual = template.merge(FileUtil.read(EXISTING));
+		
+		assertEquals(expected, actual);
 	}
 
 }

--- a/tests/org.eclipse.epsilon.egl.engine.test.unit/src/org/eclipse/epsilon/egl/merge/partition/TestCommentBlockPartitioner.java
+++ b/tests/org.eclipse.epsilon.egl.engine.test.unit/src/org/eclipse/epsilon/egl/merge/partition/TestCommentBlockPartitioner.java
@@ -112,6 +112,18 @@ public abstract class TestCommentBlockPartitioner {
 		
 		assertEquals(expected, partitioner.partition(text));
 	}
+	
+	public void testPartitionSingleProtectedRegionWithEnd() {
+		final String regionContents = "This text is protected" + NEWLINE;
+		final String text           = startComment + "protected region test endpoint off begin" + endComment + NEWLINE +
+		                              regionContents +
+		                              startComment + "protected region test endpoint end" + endComment;
+		
+		final Output expected = new Output(partitioner.new CommentedProtectedRegion("test endpoint", 0, false, regionContents));
+		final Output actual = partitioner.partition(text);
+		
+		assertEquals(expected, actual);
+	}
 
 	public void testPartitionSingleProtectedRegionWhiteSpace() {
 		final String start = (startComment.length() > 0 ? startComment + "\t" : "");

--- a/tests/org.eclipse.epsilon.egl.engine.test.unit/src/org/eclipse/epsilon/egl/merge/partition/TestJavaPartitioner.java
+++ b/tests/org.eclipse.epsilon.egl.engine.test.unit/src/org/eclipse/epsilon/egl/merge/partition/TestJavaPartitioner.java
@@ -53,6 +53,11 @@ public class TestJavaPartitioner extends TestCommentBlockPartitioner {
 	}
 	
 	@Test @Override
+	public void testPartitionSingleProtectedRegionWithEnd() {
+		super.testPartitionSingleProtectedRegionWithEnd();
+	}
+	
+	@Test @Override
 	public void testPartitionSingleProtectedRegionWhiteSpace() {
 		super.testPartitionSingleProtectedRegionWhiteSpace();
 	}


### PR DESCRIPTION
We found an edge case in the new line-by-line pattern protected region matching. If the protected region ID contained ` end`, the regex match incorrectly considered this the end of the protected region.

I tried to change the regex to something that would handle this case, but anything I could come up with broke something else - usually two protected regions on the same line (an end and another start).

So, I went with a different approach where I match all `// protected region` markers, then I can separately match the ID and the rest of the marker. Doing it this way allowed me to split a line into multiple segments and handle them individually.

It's a bit of a refactor, but it seems to be working a lot better for me now!