### PR TITLE
Some tests fail when run from Windows

### DIFF
--- a/plugins/org.eclipse.epsilon.common/src/org/eclipse/epsilon/common/util/FileUtil.java
+++ b/plugins/org.eclipse.epsilon.common/src/org/eclipse/epsilon/common/util/FileUtil.java
@@ -479,9 +479,13 @@ public class FileUtil {
 	 */
 	public static Map<Path, byte[]> readDirectory(final Path dir) throws IOException {		
 		Map<Path, byte[]> contents = new HashMap<>();
-		for (Path path : ((Iterable<Path>)Files.walk(dir)::iterator)) {
-			if (Files.isRegularFile(path)) {
-				contents.put(path, Files.readAllBytes(path));
+		try (Stream<Path> pathStream = Files.walk(dir)) {
+			Iterator<Path> itPaths = pathStream.iterator();
+			while (itPaths.hasNext()) {
+				Path path = itPaths.next();
+				if (Files.isRegularFile(path)) {
+					contents.put(path, Files.readAllBytes(path));
+				}
 			}
 		}
 		return contents;

--- a/plugins/org.eclipse.epsilon.common/src/org/eclipse/epsilon/common/util/FileUtil.java
+++ b/plugins/org.eclipse.epsilon.common/src/org/eclipse/epsilon/common/util/FileUtil.java
@@ -359,8 +359,8 @@ public class FileUtil {
 			
 			// Compare each line (ignoring line endings)
 			while (expectedIterator.hasNext() && actualIterator.hasNext()) {
-				String expected = expectedIterator.next();
-				String actual = actualIterator.next();
+				final String expected = expectedIterator.next();
+				final String actual = actualIterator.next();
 				
 				if (!expected.equals(actual)) {
 					return false;

--- a/plugins/org.eclipse.epsilon.common/src/org/eclipse/epsilon/common/util/FileUtil.java
+++ b/plugins/org.eclipse.epsilon.common/src/org/eclipse/epsilon/common/util/FileUtil.java
@@ -326,7 +326,7 @@ public class FileUtil {
 	 * We implement our own comparison algorithm here, so we don't need Eclipse
 	 * Compare to compute differences, but rather only to show them in the UI.
 	 */
-	public static boolean sameContents(File fileExpected, File fileActual, Set<String> ignoreFilenames) throws IOException {
+	public static boolean sameContents(File fileExpected, File fileActual, Set<String> ignoreFilenames, boolean ignoreLineEndings) throws IOException {
 		if (fileExpected.isDirectory() != fileActual.isDirectory()) {
 			// One is a file, the other is a directory: not the same
 			return false;
@@ -352,6 +352,24 @@ public class FileUtil {
 			}
 			return true;
 		}
+		else if (ignoreLineEndings) {
+			// Use stream iterators to read the files
+			final Iterator<String> expectedIterator = Files.lines(fileExpected.toPath()).iterator();
+			final Iterator<String> actualIterator = Files.lines(fileActual.toPath()).iterator();
+			
+			// Compare each line (ignoring line endings)
+			while (expectedIterator.hasNext() && actualIterator.hasNext()) {
+				String expected = expectedIterator.next();
+				String actual = actualIterator.next();
+				
+				if (!expected.equals(actual)) {
+					return false;
+				}
+			}
+		    
+			// Ensure that both files have no further content
+			return !expectedIterator.hasNext() && !actualIterator.hasNext();
+		}
 		else {
 			if (fileExpected.length() != fileActual.length()) {
 				// Different length: no need to read the files
@@ -364,6 +382,10 @@ public class FileUtil {
 				}
 			}
 		}
+	}
+	
+	public static boolean sameContents(File fileExpected, File fileActual, Set<String> ignoreFilenames) throws IOException {
+		return sameContents(fileExpected, fileActual, ignoreFilenames, false);
 	}
 
 	public static boolean sameContents(InputStream isExpected, InputStream isActual) throws IOException {

--- a/plugins/org.eclipse.epsilon.eol.dap/src/org/eclipse/epsilon/eol/dap/EpsilonDebugAdapter.java
+++ b/plugins/org.eclipse.epsilon.eol.dap/src/org/eclipse/epsilon/eol/dap/EpsilonDebugAdapter.java
@@ -549,8 +549,16 @@ public class EpsilonDebugAdapter implements IDebugProtocolServer, IEpsilonDebugT
 
 		// First, try to use the URI-to-path mappings
 		if (resolvedModule.getUri().getPath() != null) {
-			String path = resolvedModule.getUri().getPath();
-			String basename = Paths.get(path).getFileName().toString();
+			Path path;
+			
+			// URI#getPath() does not correctly convert `file:/` URIs to valid paths on Windows, so use Paths#get(URI) instead
+			if (resolvedModule.getUri().getScheme().equals("file")) {
+				path = Paths.get(resolvedModule.getUri());
+			} else {
+				path = Paths.get(resolvedModule.getUri().getPath());
+			}
+
+			String basename = path.getFileName().toString();
 			bpSource.setName(basename);
 			mapUriToSourcePath(resolvedModule.getUri().toString(), bpSource);
 		}

--- a/plugins/org.eclipse.epsilon.eol.dap/src/org/eclipse/epsilon/eol/dap/EpsilonDebugAdapter.java
+++ b/plugins/org.eclipse.epsilon.eol.dap/src/org/eclipse/epsilon/eol/dap/EpsilonDebugAdapter.java
@@ -552,7 +552,7 @@ public class EpsilonDebugAdapter implements IDebugProtocolServer, IEpsilonDebugT
 			Path path;
 			
 			// URI#getPath() does not correctly convert `file:/` URIs to valid paths on Windows, so use Paths#get(URI) instead
-			if (resolvedModule.getUri().getScheme().equals("file")) {
+			if ("file".equals(resolvedModule.getUri().getScheme())) {
 				path = Paths.get(resolvedModule.getUri());
 			} else {
 				path = Paths.get(resolvedModule.getUri().getPath());

--- a/plugins/org.eclipse.epsilon.eunit.engine/src/org/eclipse/epsilon/eunit/operations/ExtraEUnitOperationContributor.java
+++ b/plugins/org.eclipse.epsilon.eunit.engine/src/org/eclipse/epsilon/eunit/operations/ExtraEUnitOperationContributor.java
@@ -61,6 +61,10 @@ public class ExtraEUnitOperationContributor extends OperationContributor {
 	public void assertEqualFiles(String pathExpected, String pathActual) throws EolAssertionException, EolInternalException {
 		compareTrees(pathExpected, pathActual, true);
 	}
+	
+	public void assertEqualFilesIgnoringLineEndings(String pathExpected, String pathActual) throws EolAssertionException, EolInternalException {
+		compareTrees(pathExpected, pathActual, true, true);
+	}
 
 	public void assertEqualDirectories(String pathExpected, String pathActual) throws EolAssertionException, EolInternalException {
 		compareTrees(pathExpected, pathActual, true);
@@ -84,6 +88,10 @@ public class ExtraEUnitOperationContributor extends OperationContributor {
 
 	public void assertNotEqualFiles(String pathExpected, String pathActual) throws EolAssertionException, EolInternalException {
 		compareTrees(pathExpected, pathActual, false);
+	}
+	
+	public void assertNotEqualFilesIgnoringLineEndings(String pathExpected, String pathActual) throws EolAssertionException, EolInternalException {
+		compareTrees(pathExpected, pathActual, false, true);
 	}
 
 	public void assertNotEqualDirectories(String pathExpected, String pathActual) throws EolAssertionException, EolInternalException {
@@ -150,13 +158,17 @@ public class ExtraEUnitOperationContributor extends OperationContributor {
 	}
 
 	private void compareTrees(final String pathExpected, final String pathActual, boolean mustBeEqual) throws EolAssertionException, EolInternalException {
+		compareTrees(pathExpected, pathActual, mustBeEqual, false);
+	}
+	
+	private void compareTrees(final String pathExpected, final String pathActual, boolean mustBeEqual, boolean ignoreLineEndings) throws EolAssertionException, EolInternalException {
 		File fileExpected = new File(pathExpected);
 		File fileActual = new File(pathActual);
 		try {
 			// Compare and check against results
 			FileUtil.checkFileExists(fileExpected);
 			FileUtil.checkFileExists(fileActual);
-			if (FileUtil.sameContents(fileExpected, fileActual, ASSERTEQUALDIRS_IGNORED_FILENAMES) == mustBeEqual) {
+			if (FileUtil.sameContents(fileExpected, fileActual, ASSERTEQUALDIRS_IGNORED_FILENAMES, ignoreLineEndings) == mustBeEqual) {
 				return;
 			}
 

--- a/tests/org.eclipse.epsilon.eol.dap.test/src/org/eclipse/epsilon/eol/dap/test/eol/StandaloneEolTest.java
+++ b/tests/org.eclipse.epsilon.eol.dap.test/src/org/eclipse/epsilon/eol/dap/test/eol/StandaloneEolTest.java
@@ -94,7 +94,10 @@ public class StandaloneEolTest extends AbstractEpsilonDebugAdapterTest {
 		// Execution should complete successfully
 		assertProgramCompletedSuccessfully();
 
-		assertEquals("Hello Bob Someone\nHello Alice Important\n", getStdout());
+		final String expected = "Hello Bob Someone" + System.getProperty("line.separator") + "Hello Alice Important"
+				+ System.getProperty("line.separator");
+
+		assertEquals(expected, getStdout());
 	}
 
 	@Test

--- a/tests/org.eclipse.epsilon.eol.dap.test/src/org/eclipse/epsilon/eol/dap/test/eol/StandaloneEolTest.java
+++ b/tests/org.eclipse.epsilon.eol.dap.test/src/org/eclipse/epsilon/eol/dap/test/eol/StandaloneEolTest.java
@@ -94,8 +94,10 @@ public class StandaloneEolTest extends AbstractEpsilonDebugAdapterTest {
 		// Execution should complete successfully
 		assertProgramCompletedSuccessfully();
 
-		final String expected = "Hello Bob Someone" + System.getProperty("line.separator") + "Hello Alice Important"
-				+ System.getProperty("line.separator");
+		final String expected = "Hello Bob Someone"
+			+ System.lineSeparator()
+			+ "Hello Alice Important"
+			+ System.lineSeparator();
 
 		assertEquals(expected, getStdout());
 	}

--- a/tests/org.eclipse.epsilon.workflow.test/src/org/eclipse/epsilon/workflow/resources/eunit/egl/file-tests.eunit
+++ b/tests/org.eclipse.epsilon.workflow.test/src/org/eclipse/epsilon/workflow/resources/eunit/egl/file-tests.eunit
@@ -71,7 +71,7 @@ operation deleteGeneratedDir() {
 operation expectedModelGeneratesExpectedFile() {
   loadHutn("Tree", EXPECTED_MODEL);
   runTarget("tree2text");
-  assertEqualFiles(EXPECTED_PATH, GENERATED_PATH);
+  assertEqualFilesIgnoringLineEndings(EXPECTED_PATH, GENERATED_PATH);
 }
 
 @test
@@ -79,7 +79,7 @@ operation expectedModelGeneratesExpectedFileFailing() {
   loadHutn("Tree", EXPECTED_MODEL);
   runTarget("tree2text");
   // this test must fail
-  assertNotEqualFiles(EXPECTED_PATH, GENERATED_PATH);
+  assertNotEqualFilesIgnoringLineEndings(EXPECTED_PATH, GENERATED_PATH);
 }
 
 @test


### PR DESCRIPTION
I found a couple problems when running the test suite from my Windows computer. 

1. The new EpsilonDebugAdapter tests contain a code path which calls `URI#getPath()`, however this produces an invalid file path on Windows when the URI is a `file:` URI. Using `Paths#get(URI)` produces a valid Windows file path. Additionally, there were some hard coded Unix line endings in some expected values.

2. Some of the EUnit tests compare an expected file on the filesystem with a generated file. The expected file has Unix line endings, but a generated file on Windows will produce a file with Windows line endings. The current comparison method will (rather correctly) indicate these files are not equal. I've added 2 new EUnit assertion operations to compare files ignoring line endings, allowing users to opt in to this slightly relaxed behavior should they desire it.

~~I wasn't able to find where the source code for the [documentation](https://eclipse.dev/epsilon/doc/eunit/#assertions) resides, so I wasn't able to update it. Please let me know where I can find it and I'd be happy to update it.~~
EDIT: I found it! I've added a PR for the above changes https://github.com/eclipse/epsilon-website/pull/34

EDIT: There were mixed line endings in `FileUtil.java`, so I standardised them to Unix. Sorry for the big whitespace diff! 😅