### PR TITLE
[DAP] Add support for conditional breakpoints (fixes #121)

### DIFF
--- a/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/debug/BreakpointRequest.java
+++ b/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/debug/BreakpointRequest.java
@@ -22,6 +22,7 @@ public class BreakpointRequest {
 	private final Map<URI, Path> uriToPathMappings;
 	private final String path;
 	private final int line;
+	private final String condition;
 
 	/**
 	 * Constructs a new request.
@@ -32,11 +33,15 @@ public class BreakpointRequest {
 	 * @param path              Absolute path of the IDE file with the breakpoint.
 	 * @param line              1-based index of the line of the file where the
 	 *                          breakpoint has been set.
+	 * @param condition         EOL-based condition that must hold in order to stop
+	 *                          at the line. Can be <code>null</code> if no
+	 *                          condition is to be used.
 	 */
-	public BreakpointRequest(Map<URI, Path> uriToPathMappings, String path, int line) {
+	public BreakpointRequest(Map<URI, Path> uriToPathMappings, String path, int line, String condition) {
 		this.uriToPathMappings = uriToPathMappings;
 		this.path = path;
 		this.line = line;
+		this.condition = condition;
 	}
 
 	public String getPath() {
@@ -49,6 +54,10 @@ public class BreakpointRequest {
 
 	public Map<URI, Path> getUriToPathMappings() {
 		return uriToPathMappings;
+	}
+
+	public String getCondition() {
+		return condition;
 	}
 
 	@Override

--- a/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/debug/BreakpointResult.java
+++ b/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/debug/BreakpointResult.java
@@ -12,7 +12,6 @@ package org.eclipse.epsilon.eol.debug;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.logging.Logger;
 
 import org.eclipse.epsilon.common.module.IModule;
 
@@ -26,7 +25,6 @@ import org.eclipse.epsilon.common.module.IModule;
  */
 public class BreakpointResult {
 
-	private static final Logger LOGGER = Logger.getLogger(BreakpointResult.class.getName());
 	public static final int NOT_FOUND = -1;
 
 	private final BreakpointRequest request;
@@ -34,28 +32,30 @@ public class BreakpointResult {
 	private final IModule module;
 	private final URI moduleURI;
 	private final int line;
+	private final String condition;
 	private final BreakpointState state;
 
-	private BreakpointResult(BreakpointRequest request, IModule module, URI moduleURI, int line, BreakpointState state) {
+	private BreakpointResult(BreakpointRequest request, IModule module, URI moduleURI, int line, String condition, BreakpointState state) {
 		this.request = request;
 		this.module = module;
 		this.moduleURI = moduleURI;
 		this.line = line;
+		this.condition = condition;
 		this.state = state;
 	}
 
 	public static BreakpointResult failed(BreakpointRequest request) {
-		return new BreakpointResult(request, null, null, NOT_FOUND, BreakpointState.FAILED);
+		return new BreakpointResult(request, null, null, NOT_FOUND, request.getCondition(), BreakpointState.FAILED);
 	}
 
 	public static BreakpointResult verified(BreakpointRequest request, IModule module, int actualLine) {
-		return new BreakpointResult(request, module, module.getSourceUri(), actualLine, BreakpointState.VERIFIED);
+		return new BreakpointResult(request, module, module.getSourceUri(), actualLine, request.getCondition(), BreakpointState.VERIFIED);
 	}
 
 	public static BreakpointResult pending(BreakpointRequest request) {
 		final Path requestPath = Paths.get(request.getPath());
 		final URI requestURI = requestPath.toUri();
-		return new BreakpointResult(request, null, requestURI, request.getLine(), BreakpointState.PENDING);
+		return new BreakpointResult(request, null, requestURI, request.getLine(), request.getCondition(), BreakpointState.PENDING);
 	}
 
 	public BreakpointRequest getRequest() {
@@ -76,6 +76,10 @@ public class BreakpointResult {
 
 	public BreakpointState getState() {
 		return state;
+	}
+
+	public String getCondition() {
+		return condition;
 	}
 
 }

--- a/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/debug/EolDebugger.java
+++ b/plugins/org.eclipse.epsilon.eol.engine/src/org/eclipse/epsilon/eol/debug/EolDebugger.java
@@ -289,10 +289,15 @@ public class EolDebugger implements IEolDebugger {
 	}
 
 	protected void addAllModules(Map<String, IModule> pathToModule, IModule module) throws IOException {
-		String moduleURI = module.getFile() != null
-			? module.getFile().getCanonicalFile().toURI().toString() : module.getUri().toString();
+		// Note: mini-modules set up to run breakpoint conditions won't have a URI
+		String moduleURI = null;
+		if (module.getFile() != null) {
+			moduleURI = module.getFile().getCanonicalFile().toURI().toString();
+		} else if (module.getUri() != null) {
+			moduleURI = module.getUri().toString();
+		}
 
-		if (!pathToModule.containsKey(moduleURI)) {
+		if (moduleURI != null && !pathToModule.containsKey(moduleURI)) {
 			pathToModule.put(moduleURI, module);
 			if (module instanceof IEolModule) {
 				for (Import imp : ((IEolModule) module).getImports()) {

--- a/tests/org.eclipse.epsilon.eol.dap.test/src/org/eclipse/epsilon/eol/dap/test/EpsilonDebugServerTest.java
+++ b/tests/org.eclipse.epsilon.eol.dap.test/src/org/eclipse/epsilon/eol/dap/test/EpsilonDebugServerTest.java
@@ -99,6 +99,7 @@ public class EpsilonDebugServerTest {
 			Capabilities initResponse = remoteProxy.initialize(args).get(5, TimeUnit.SECONDS);
 			assertNotNull("The adapter should have replied with its capabilities", initResponse);
 			assertTrue("The adapter should say terminate is supported", initResponse.getSupportsTerminateRequest());
+			assertTrue("The adapter should say conditional breakpoints are supported", initResponse.getSupportsConditionalBreakpoints());
 
 			CompletableFuture<Void> waitForAttach = remoteProxy.attach(Collections.emptyMap());
 			waitForAttach.get(5, TimeUnit.SECONDS);


### PR DESCRIPTION
This PR adds support for conditional breakpoints to our DAP server. This works by creating a throwaway EolModule with a copy of the existing context, but with a different instance of the executor factory (as we do not want to debug the expression being evaluated), and a separate copy of the frame stack.

At the moment, this is only usable from VS Code. It appears that we would need to write some additional UI code to have it work from Eclipse: we need to add an edit view for Epsilon breakpoints for the condition, and LSP4E needs to pass on this information via DAP.

Here is what it looks like from VS Code:

![image](https://github.com/user-attachments/assets/11686091-7847-4471-9c44-4892b6595014)
